### PR TITLE
BTAT-5413 Added test-only route for manual polling of each scheduler

### DIFF
--- a/app/services/CommsEventQueuePollingService.scala
+++ b/app/services/CommsEventQueuePollingService.scala
@@ -46,7 +46,7 @@ class CommsEventQueuePollingService @Inject()(actorSystem: ActorSystem,
     s"\nInitial delay: $initialDelay" +
     s"\nPolling interval: $interval")
 
-  def executor(): Unit = {
+  def executor()(implicit ec: ExecutionContext): Unit = {
     execute.onComplete({
       case Success(Result(_)) =>
         logInfo(_)

--- a/app/services/EmailMessageQueuePollingService.scala
+++ b/app/services/EmailMessageQueuePollingService.scala
@@ -28,9 +28,9 @@ import scala.util.{Failure, Success}
 
 @Singleton
 class EmailMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
-                                    appConfig: AppConfig,
-                                    emailMessageService: EmailMessageService)
-                                    (implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
+                                                appConfig: AppConfig,
+                                                emailMessageService: EmailMessageService)
+                                                (implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
 
   override def name: String = "EmailMessageQueuePollingService"
 
@@ -45,7 +45,7 @@ class EmailMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
     s"\nInitial delay: $initialDelay" +
     s"\nPolling interval: $interval")
 
-  def executor(): Unit = {
+  def executor()(implicit ec: ExecutionContext): Unit = {
     execute.onComplete({
       case Success(Result(_)) =>
         logInfo(_)

--- a/app/services/SecureMessageQueuePollingService.scala
+++ b/app/services/SecureMessageQueuePollingService.scala
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success}
 class SecureMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
                                                  appConfig: AppConfig,
                                                  secureMessageService: SecureMessageService)(
-                                              implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
+                                                 implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
 
   override def name: String = "SecureMessageQueuePollingService"
 
@@ -45,7 +45,7 @@ class SecureMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
     s"\nInitial delay: $initialDelay" +
     s"\nPolling interval: $interval")
 
-  def executor(): Unit = {
+  def executor()(implicit ec: ExecutionContext): Unit = {
     execute.onComplete({
       case Success(Result(_)) =>
         logInfo(_)

--- a/app/testOnly/controllers/CommsEventQueueController.scala
+++ b/app/testOnly/controllers/CommsEventQueueController.scala
@@ -20,14 +20,21 @@ import controllers.MicroserviceBaseController
 import com.google.inject.Inject
 import play.api.mvc.{Action, AnyContent}
 import repositories.CommsEventQueueRepository
+import services.CommsEventQueuePollingService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CommsEventQueueController @Inject()(repository: CommsEventQueueRepository)(
+class CommsEventQueueController @Inject()(repository: CommsEventQueueRepository,
+                                          scheduler: CommsEventQueuePollingService)(
                                           implicit ec: ExecutionContext) extends MicroserviceBaseController {
 
   def count: Action[AnyContent] = Action.async { implicit request =>
     val result: Future[Int] = repository.count
     result.map(count => Ok(count.toString))
+  }
+
+  def poll: Action[AnyContent] = Action { implicit request =>
+    scheduler.executor()
+    Ok
   }
 }

--- a/app/testOnly/controllers/EmailMessageQueueController.scala
+++ b/app/testOnly/controllers/EmailMessageQueueController.scala
@@ -20,14 +20,21 @@ import controllers.MicroserviceBaseController
 import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent}
 import repositories.EmailMessageQueueRepository
+import services.EmailMessageQueuePollingService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailMessageQueueController @Inject()(repository: EmailMessageQueueRepository)(
+class EmailMessageQueueController @Inject()(repository: EmailMessageQueueRepository,
+                                            scheduler: EmailMessageQueuePollingService)(
                                             implicit ec: ExecutionContext) extends MicroserviceBaseController {
 
   def count: Action[AnyContent] = Action.async { implicit request =>
     val result: Future[Int] = repository.count
     result.map(count => Ok(count.toString))
+  }
+
+  def poll: Action[AnyContent] = Action { implicit request =>
+    scheduler.executor()
+    Ok
   }
 }

--- a/app/testOnly/controllers/SecureMessageQueueController.scala
+++ b/app/testOnly/controllers/SecureMessageQueueController.scala
@@ -20,14 +20,21 @@ import controllers.MicroserviceBaseController
 import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent}
 import repositories.SecureMessageQueueRepository
+import services.SecureMessageQueuePollingService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SecureMessageQueueController @Inject()(repository: SecureMessageQueueRepository)(
+class SecureMessageQueueController @Inject()(repository: SecureMessageQueueRepository,
+                                             scheduler: SecureMessageQueuePollingService)(
                                              implicit ec: ExecutionContext) extends MicroserviceBaseController {
 
   def count: Action[AnyContent] = Action.async { implicit request =>
     val result: Future[Int] = repository.count
     result.map(count => Ok(count.toString))
+  }
+
+  def poll: Action[AnyContent] = Action { implicit request =>
+    scheduler.executor()
+    Ok
   }
 }

--- a/conf/testOnly.routes
+++ b/conf/testOnly.routes
@@ -15,4 +15,8 @@ GET        /mtd-vat-comms/test-only/comms-event-queue/count      @testOnly.contr
 GET        /mtd-vat-comms/test-only/email-message-queue/count    @testOnly.controllers.EmailMessageQueueController.count
 GET        /mtd-vat-comms/test-only/secure-message-queue/count   @testOnly.controllers.SecureMessageQueueController.count
 
+GET        /mtd-vat-comms/test-only/comms-event-queue/poll       @testOnly.controllers.CommsEventQueueController.poll
+GET        /mtd-vat-comms/test-only/email-message-queue/poll     @testOnly.controllers.EmailMessageQueueController.poll
+GET        /mtd-vat-comms/test-only/secure-message-queue/poll    @testOnly.controllers.SecureMessageQueueController.poll
+
 ->         /                                                     prod.Routes

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -18,3 +18,7 @@ microservice {
     }
   }
 }
+
+queue {
+  toggle = false
+}

--- a/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
+++ b/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
@@ -21,13 +21,15 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.CommsEventQueueRepository
+import services.CommsEventQueuePollingService
 
 import scala.concurrent.Future
 
 class CommsEventQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: CommsEventQueueRepository = mock[CommsEventQueueRepository]
-  val controller = new CommsEventQueueController(repository)
+  val scheduler: CommsEventQueuePollingService = mock[CommsEventQueuePollingService]
+  val controller = new CommsEventQueueController(repository, scheduler)
   val recordCount = 99
 
   "The count action" should {

--- a/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
@@ -21,13 +21,15 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.EmailMessageQueueRepository
+import services.EmailMessageQueuePollingService
 
 import scala.concurrent.Future
 
 class EmailMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: EmailMessageQueueRepository = mock[EmailMessageQueueRepository]
-  val controller = new EmailMessageQueueController(repository)
+  val scheduler: EmailMessageQueuePollingService = mock[EmailMessageQueuePollingService]
+  val controller = new EmailMessageQueueController(repository, scheduler)
   val recordCount = 99
 
   "The count action" should {

--- a/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
@@ -21,13 +21,15 @@ import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.SecureMessageQueueRepository
+import services.SecureMessageQueuePollingService
 
 import scala.concurrent.Future
 
 class SecureMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: SecureMessageQueueRepository = mock[SecureMessageQueueRepository]
-  val controller = new SecureMessageQueueController(repository)
+  val scheduler: SecureMessageQueuePollingService = mock[SecureMessageQueuePollingService]
+  val controller = new SecureMessageQueueController(repository, scheduler)
   val recordCount = 99
 
   "The count action" should {


### PR DESCRIPTION
No tests were added due to the function purely being a proxy for another already tested function. Our test coverage is not affected as anything in our testOnly directory is not included in scoverage.

I also toggled the polling switch to false in the test config to prevent a Mongo closed connection exception from appearing when the IT tests were run.