### PR TITLE
BTAT-5435 Removed subject headings from HTML messages

### DIFF
--- a/app/services/SecureCommsService.scala
+++ b/app/services/SecureCommsService.scala
@@ -82,25 +82,25 @@ class SecureCommsService @Inject()(secureCommsServiceConnector: SecureCommsServi
     val businessName = messageModel.getBusinessName
     messageModel match {
       case deregModel: DeRegistrationModel =>
-        val html = getDeregistrationChangeHtml(deregModel, isApproval, isTransactor)
+        val html = getDeregistrationChangeHtml(deregModel, isApproval)
         val subject = getSubjectForBaseKey(baseSubjectKey = DEREG_BASE_KEY, isApproval, isTransactor)
         buildSecureCommsServiceRequestModel(
           html, deregModel.customerDetails.customerEmail, subject, vrn, businessName, isTransactor
         )
       case ppobModel: PPOBChangeModel =>
-        val html = getPpobChangeHtml(ppobModel, isApproval, isTransactor)
+        val html = getPpobChangeHtml(ppobModel, isApproval)
         val subject = getSubjectForBaseKey(baseSubjectKey = PPOB_BASE_KEY, isApproval, isTransactor)
         buildSecureCommsServiceRequestModel(
           html, ppobModel.customerDetails.customerEmail, subject, vrn, businessName, isTransactor
         )
       case repaymentModel: RepaymentsBankAccountChangeModel =>
-        val html = getBankDetailsChangeHtml(repaymentModel, isApproval, isTransactor)
+        val html = getBankDetailsChangeHtml(repaymentModel, isApproval)
         val subject = getSubjectForBaseKey(baseSubjectKey = BANK_DETAILS_BASE_KEY, isApproval, isTransactor)
         buildSecureCommsServiceRequestModel(
           html, repaymentModel.customerDetails.customerEmail, subject, vrn, businessName, isTransactor
         )
       case staggerModel: VATStaggerChangeModel =>
-        val html = getStaggerChangeHtml(staggerModel, isApproval, isTransactor)
+        val html = getStaggerChangeHtml(staggerModel, isApproval)
         val subject = getSubjectForBaseKey(baseSubjectKey = STAGGER_BASE_KEY, isApproval, isTransactor)
         buildSecureCommsServiceRequestModel(
           html, staggerModel.customerDetails.customerEmail, subject, vrn, businessName, isTransactor
@@ -141,53 +141,51 @@ class SecureCommsService @Inject()(secureCommsServiceConnector: SecureCommsServi
   }
 
   private def getBankDetailsChangeHtml(repaymentsBankAccountChangeModel: RepaymentsBankAccountChangeModel,
-                                       isApproval: Boolean,
-                                       isTransactor: Boolean): String = {
+                                       isApproval: Boolean): String = {
     if (isApproval) {
       vatBankDetailsApproved(repaymentsBankAccountChangeModel.bankAccountDetails.bankAccountName,
         repaymentsBankAccountChangeModel.bankAccountDetails.bankSortCode,
-        repaymentsBankAccountChangeModel.bankAccountDetails.bankAccountNumber, isTransactor).toString
+        repaymentsBankAccountChangeModel.bankAccountDetails.bankAccountNumber).toString
     } else {
       vatBankDetailsRejected(repaymentsBankAccountChangeModel.bankAccountDetails.bankAccountName,
-        repaymentsBankAccountChangeModel.businessName, isTransactor).toString
+        repaymentsBankAccountChangeModel.businessName).toString
     }
   }
 
   private def getDeregistrationChangeHtml(deRegistrationModel: DeRegistrationModel,
-                                          isApproval: Boolean, isTransactor: Boolean): String = {
+                                          isApproval: Boolean): String = {
     if (isApproval) {
-      vatDeregApproved(etmpToFullMonthDateString(deRegistrationModel.effectiveDateOfDeRegistration), isTransactor).toString
+      vatDeregApproved(etmpToFullMonthDateString(deRegistrationModel.effectiveDateOfDeRegistration)).toString
     } else {
-      vatDeregRejected(isTransactor).toString
+      vatDeregRejected().toString
     }
   }
 
   private def getPpobChangeHtml(ppobChangeModel: PPOBChangeModel,
-                                isApproval: Boolean,
-                                isTransactor: Boolean): String = {
+                                isApproval: Boolean): String = {
     if (isApproval) {
       vatPPOBApproved(
-        VatPPOBViewModel
-        (ppobChangeModel.addressDetails.addressLine1,
+        VatPPOBViewModel(
+          ppobChangeModel.addressDetails.addressLine1,
           ppobChangeModel.addressDetails.addressLine2,
           if (ppobChangeModel.addressDetails.addressLine3.isEmpty) None else Some(ppobChangeModel.addressDetails.addressLine3),
           if (ppobChangeModel.addressDetails.addressLine4.isEmpty) None else Some(ppobChangeModel.addressDetails.addressLine4),
           if (ppobChangeModel.addressDetails.addressLine5.isEmpty) None else Some(ppobChangeModel.addressDetails.addressLine5),
           if (ppobChangeModel.addressDetails.postCode.isEmpty) None else Some(ppobChangeModel.addressDetails.postCode),
-          if (ppobChangeModel.addressDetails.countryName.isEmpty) None else Some(ppobChangeModel.addressDetails.countryName)),
-        isTransactor).toString
+          if (ppobChangeModel.addressDetails.countryName.isEmpty) None else Some(ppobChangeModel.addressDetails.countryName)
+        )
+      ).toString
     } else {
-      vatPPOBRejected(isTransactor).toString
+      vatPPOBRejected().toString
     }
   }
 
   private def getStaggerChangeHtml(vatStaggerChangeModel: VATStaggerChangeModel,
-                                   isApproval: Boolean,
-                                   isTransactor: Boolean): String = {
+                                   isApproval: Boolean): String = {
     if (isApproval) {
-      vatStaggerApproved(vatStaggerChangeModel.stagger, isTransactor).toString
+      vatStaggerApproved(vatStaggerChangeModel.stagger).toString
     } else {
-      vatStaggerRejected(isTransactor).toString
+      vatStaggerRejected().toString
     }
   }
 

--- a/app/views/vatBankDetailsApproved.scala.html
+++ b/app/views/vatBankDetailsApproved.scala.html
@@ -14,17 +14,10 @@
  * limitations under the License.
  *@
 
-@(accountName: String, sortCode: String, accountNumber: String, isTransactor: Boolean)(implicit messages: MessagesApi)
+@(accountName: String, sortCode: String, accountNumber: String)(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("bankDetailsApprovedTransactor.title")
-            } else {
-                @messages("bankDetailsApproved.title")
-            }
-        </h2>
         <p>@messages("bankDetailsApproved.p1")</p>
         <p>
           <strong>@messages("bankDetailsApproved.p2")</strong> @accountName<br>

--- a/app/views/vatBankDetailsRejected.scala.html
+++ b/app/views/vatBankDetailsRejected.scala.html
@@ -14,24 +14,17 @@
  * limitations under the License.
  *@
 
-@(accountName: String, businessName: String, isTransactor: Boolean)(implicit messages: MessagesApi)
+@(accountName: String, businessName: String)(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("bankDetailsRejectedTransactor.title")
-            } else {
-                @messages("bankDetailsRejected.title")
-            }
-        </h2>
         <p>@messages("bankDetailsRejected.p1")</p>
         <p>
           <strong>@messages("bankDetailsRejected.p2")</strong> @accountName<br>
           <strong>@messages("bankDetailsRejected.p3")</strong> @businessName
         </p>
         <p>@messages("bankDetailsRejected.p4")</p>
-        <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
+        <h2 class="heading-small">@messages("common.whatHappensNext")</h2>
         <p>@messages("common.standardReject")</p>
         <p>
             @messages("common.hmrcAddressLine1")<br>

--- a/app/views/vatDeregApproved.scala.html
+++ b/app/views/vatDeregApproved.scala.html
@@ -14,19 +14,12 @@
  * limitations under the License.
  *@
 
-@(deregDate: String, isTransactor: Boolean)(implicit messages: MessagesApi)
+@(deregDate: String)(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("deregApprovedTransactor.title")
-            } else {
-                @messages("deregApproved.title")
-            }
-        </h2>
         <p>@messages("deregApproved.p1", deregDate)</p>
-        <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
+        <h2 class="heading-small">@messages("common.whatHappensNext")</h2>
         <p>@messages("deregApproved.p2", deregDate)</p>
         <p>@messages("deregApproved.p3")</p>
     </div>

--- a/app/views/vatDeregRejected.scala.html
+++ b/app/views/vatDeregRejected.scala.html
@@ -16,19 +16,12 @@
 
 @import config.AppConfig
 
-@(isTransactor: Boolean)(implicit messages: MessagesApi, appConfig: AppConfig)
+@()(implicit messages: MessagesApi, appConfig: AppConfig)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("deregRejectedTransactor.title")
-            } else {
-                @messages("deregRejected.title")
-            }
-        </h2>
         <p>@messages("deregRejected.p1")</p>
-        <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
+        <h2 class="heading-small">@messages("common.whatHappensNext")</h2>
         <p>@messages("deregRejected.p2")</p>
         <p>@messages("common.standardReject")</p>
         <p>

--- a/app/views/vatEmailApproved.scala.html
+++ b/app/views/vatEmailApproved.scala.html
@@ -18,7 +18,6 @@
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">@messages("emailApproved.title")</h2>
         <p>@messages("emailApproved.p1", email)</p>
     </div>
 </div>

--- a/app/views/vatEmailRejected.scala.html
+++ b/app/views/vatEmailRejected.scala.html
@@ -18,7 +18,6 @@
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">@messages("emailRejected.title")</h2>
         <p>@messages("emailRejected.p1")</p>
         <p>@messages("common.standardReject")</p>
         <p>

--- a/app/views/vatPPOBApproved.scala.html
+++ b/app/views/vatPPOBApproved.scala.html
@@ -16,17 +16,10 @@
 
 @import models.viewModels.VatPPOBViewModel
 
-@(model: VatPPOBViewModel, isTransactor: Boolean)(implicit messages: MessagesApi)
+@(model: VatPPOBViewModel)(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("ppobApprovedTransactor.title")
-            } else {
-                @messages("ppobApproved.title")
-            }
-        </h2>
         <p>@messages("ppobApproved.p1")</p>
         <p>
           @model.addressLine1<br>

--- a/app/views/vatPPOBRejected.scala.html
+++ b/app/views/vatPPOBRejected.scala.html
@@ -16,24 +16,17 @@
 
 @import config.AppConfig
 
-@(isTransactor: Boolean)(implicit messages: MessagesApi, appConfig: AppConfig)
+@()(implicit messages: MessagesApi, appConfig: AppConfig)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-                @messages("ppobRejectedTransactor.title")
-            } else {
-                @messages("ppobRejected.title")
-            }
-        </h2>
         <p>@messages("ppobRejected.p1")</p>
         <ul class="list list-bullet">
             <li>@messages("ppobRejected.bullet1")</li>
             <li>@messages("ppobRejected.bullet2")</li>
             <li>@messages("ppobRejected.bullet3")</li>
         </ul>
-        <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
+        <h2 class="heading-small">@messages("common.whatHappensNext")</h2>
         <p>
           <a href=@appConfig.manageVatSubscriptionUrl>@messages("ppobRejected.link")</a> @messages("ppobRejected.p2")
         </p>

--- a/app/views/vatStaggerApproved.scala.html
+++ b/app/views/vatStaggerApproved.scala.html
@@ -16,17 +16,10 @@
 
 @import views.html.templates.displayStagger
 
-@(stagger: String, isTransactor: Boolean)(implicit messages: MessagesApi)
+@(stagger: String)(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-medium">
-            @if(isTransactor) {
-            @messages("staggerApprovedTransactor.title")
-            } else {
-            @messages("staggerApproved.title")
-            }
-        </h2>
         <p>@messages("staggerApproved.p1") @displayStagger(stagger)</p>
         <p>@messages("staggerApproved.p2")</p>
     </div>

--- a/app/views/vatStaggerRejected.scala.html
+++ b/app/views/vatStaggerRejected.scala.html
@@ -14,18 +14,11 @@
  * limitations under the License.
  *@
 
-@(isTransactor: Boolean)(implicit messages: MessagesApi)
+@()(implicit messages: MessagesApi)
 
 <div class="grid-row">
     <div class="column-two-thirds">
-        <h2 class="heading-large">
-            @if(isTransactor) {
-                @messages("staggerRejectedTransactor.title")
-            } else {
-                @messages("staggerRejected.title")
-            }
-        </h2>
-        <h2 class="heading-medium">@messages("common.whatHappensNext")</h2>
+        <h2 class="heading-small">@messages("common.whatHappensNext")</h2>
         <p>@messages("staggerRejected.p1")</p>
         <p>@messages("common.standardReject")</p>
         <p>

--- a/test/views/VatBankDetailsApprovedViewSpec.scala
+++ b/test/views/VatBankDetailsApprovedViewSpec.scala
@@ -21,42 +21,17 @@ import org.jsoup.nodes.Document
 
 class VatBankDetailsApprovedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatBankDetailsApproved secure message content for a client" should {
+  "Rendering the VatBankDetailsApproved secure message content" should {
 
-    lazy val view = views.html.vatBankDetailsApproved("Mickey Flanagan", "21****", "****3218", isTransactor = false)
+    lazy val view = views.html.vatBankDetailsApproved("Mickey Flanagan", "21****", "****3218")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your bank details for VAT repayments"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "Your new bank details for VAT repayments are:"
+      elementText("p:nth-child(1)") shouldBe "Your new bank details for VAT repayments are:"
     }
 
     "have the correct user information" in {
-      elementText("p:nth-child(3)") shouldBe
-        "Account name: Mickey Flanagan " +
-          "Sort code: 21**** " +
-          "Account number: ****3218"
-    }
-  }
-
-  "Rendering the VatBankDetailsApproved secure message content when a transactor" should {
-
-    lazy val view = views.html.vatBankDetailsApproved("Mickey Flanagan", "21****", "****3218", isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your bank details for VAT repayments"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "Your new bank details for VAT repayments are:"
-    }
-
-    "have the correct user information" in {
-      elementText("p:nth-child(3)") shouldBe
+      elementText("p:nth-child(2)") shouldBe
         "Account name: Mickey Flanagan " +
           "Sort code: 21**** " +
           "Account number: ****3218"

--- a/test/views/VatBankDetailsRejectedViewSpec.scala
+++ b/test/views/VatBankDetailsRejectedViewSpec.scala
@@ -21,86 +21,40 @@ import org.jsoup.nodes.Document
 
 class VatBankDetailsRejectedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatBankDetailsRejected secure message content when a client" should {
+  "Rendering the VatBankDetailsRejected secure message content" should {
 
-    lazy val view = views.html.vatBankDetailsRejected("Mickey Flanagan", "Acme Dynamite Solutions", isTransactor = false)
+    lazy val view = views.html.vatBankDetailsRejected("Mickey Flanagan", "Acme Dynamite Solutions")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected the change to your bank details for VAT repayments"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe
+      elementText("p:nth-child(1)") shouldBe
         "This is because the bank account name is different from the business name on your VAT certificate."
     }
 
     "have the correct user information" in {
-      elementText("p:nth-child(3)") shouldBe
+      elementText("p:nth-child(2)") shouldBe
         "Bank account name: Mickey Flanagan " +
           "Business name: Acme Dynamite Solutions"
     }
 
     "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe
+      elementText("p:nth-child(3)") shouldBe
         "HMRC can only make payments to the bank account that belongs to the registered business."
     }
 
-    "have the correct second h2" in {
-      elementText("h2:nth-child(5)") shouldBe "What happens next"
+    "have the correct h2" in {
+      elementText("h2") shouldBe "What happens next"
     }
 
     "have the correct third paragraph" in {
-      elementText("div > div > p:nth-child(6)") shouldBe
+      elementText("div > div > p:nth-child(5)") shouldBe
         "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
           "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
           "giving the reasons why you do not agree with our decision. Write to:"
     }
 
     "have the correct HMRC address as the final paragraph" in {
-      elementText("div > div > p:nth-child(7)") shouldBe
-        "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
-    }
-  }
-
-  "Rendering the VatBankDetailsRejected secure message content when a transactor" should {
-
-    lazy val view = views.html.vatBankDetailsRejected("Mickey Flanagan", "Acme Dynamite Solutions", isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected your agent’s change to your bank details for VAT repayments"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe
-        "This is because the bank account name is different from the business name on your VAT certificate."
-    }
-
-    "have the correct user information" in {
-      elementText("p:nth-child(3)") shouldBe
-        "Bank account name: Mickey Flanagan " +
-          "Business name: Acme Dynamite Solutions"
-    }
-
-    "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe
-        "HMRC can only make payments to the bank account that belongs to the registered business."
-    }
-
-    "have the correct second h2" in {
-      elementText("h2:nth-child(5)") shouldBe "What happens next"
-    }
-
-    "have the correct third paragraph" in {
       elementText("div > div > p:nth-child(6)") shouldBe
-        "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
-          "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
-          "giving the reasons why you do not agree with our decision. Write to:"
-    }
-
-    "have the correct HMRC address as the final paragraph" in {
-      elementText("div > div > p:nth-child(7)") shouldBe
         "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
     }
   }

--- a/test/views/VatDeregApprovedViewSpec.scala
+++ b/test/views/VatDeregApprovedViewSpec.scala
@@ -21,59 +21,26 @@ import org.jsoup.nodes.Document
 
 class VatDeregApprovedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatDeregApproved secure message content for a client" should {
+  "Rendering the VatDeregApproved secure message content" should {
 
-    lazy val view = views.html.vatDeregApproved("03 October 2018", isTransactor = false)
+    lazy val view = views.html.vatDeregApproved("03 October 2018")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have accepted your request to deregister from VAT"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "The business will be deregistered from VAT on 03 October 2018."
+      elementText("p:nth-child(1)") shouldBe "The business will be deregistered from VAT on 03 October 2018."
     }
 
     "have the correct second h2" in {
-      elementText("h2:nth-child(3)") shouldBe "What happens next"
+      elementText("h2:nth-child(2)") shouldBe "What happens next"
     }
 
     "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe "Submit any outstanding VAT Returns which cover " +
+      elementText("p:nth-child(3)") shouldBe "Submit any outstanding VAT Returns which cover " +
         "the period up to 03 October 2018."
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(5)") shouldBe "Register for VAT again if your taxable turnover " +
-        "goes above the VAT threshold."
-    }
-
-  }
-
-  "Rendering the VatDeregApproved secure message content for a transactor" should {
-
-    lazy val view = views.html.vatDeregApproved("03 October 2018", isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have accepted your agent’s request to deregister from VAT"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "The business will be deregistered from VAT on 03 October 2018."
-    }
-
-    "have the correct second h2" in {
-      elementText("h2:nth-child(3)") shouldBe "What happens next"
-    }
-
-    "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe "Submit any outstanding VAT Returns which cover " +
-        "the period up to 03 October 2018."
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(5)") shouldBe "Register for VAT again if your taxable turnover " +
+      elementText("p:nth-child(4)") shouldBe "Register for VAT again if your taxable turnover " +
         "goes above the VAT threshold."
     }
 

--- a/test/views/VatDeregRejectedViewSpec.scala
+++ b/test/views/VatDeregRejectedViewSpec.scala
@@ -21,95 +21,44 @@ import org.jsoup.nodes.Document
 
 class VatDeregRejectedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatDeregRejected secure message content for a client" should {
+  "Rendering the VatDeregRejected secure message content" should {
 
-    lazy val view = views.html.vatDeregRejected(isTransactor = false)
+    lazy val view = views.html.vatDeregRejected()
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected your request to deregister from VAT"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "From the information available to us, we think you are not eligible to " +
+      elementText("p:nth-child(1)") shouldBe "From the information available to us, we think you are not eligible to " +
         "deregister from VAT and will remain registered."
     }
 
-    "have the correct second h2" in {
-      elementText("h2:nth-child(3)") shouldBe "What happens next"
+    "have the correct h2" in {
+      elementText("h2") shouldBe "What happens next"
     }
 
     "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe
+      elementText("p:nth-child(3)") shouldBe
         "You can apply to deregister again if your turnover falls below the threshold."
     }
 
     "have the correct third fifth paragraph" in {
-      elementText("p:nth-child(5)") shouldBe
+      elementText("p:nth-child(4)") shouldBe
         "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
           "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
           "giving the reasons why you do not agree with our decision. Write to:"
     }
 
     "have the correct fourth paragraph" in {
-      elementText("p:nth-child(6)") shouldBe
-        "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(7)") shouldBe "You also have the option to appeal to the tax tribunal " +
-        "(opens in a new tab) to request a review of an HMRC decision."
-    }
-
-    "have a link to appeal to the tax tribunal" in {
-      elementAttributes("p:nth-child(7) > a")(document)("href") shouldBe
-        "https://www.gov.uk/tax-tribunal/appeal-to-tribunal"
-    }
-
-  }
-
-  "Rendering the VatDeregRejected secure message content for a transactor" should {
-
-    lazy val view = views.html.vatDeregRejected(isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected your agent’s request to deregister your business from VAT"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "From the information available to us, we think you are not eligible to " +
-        "deregister from VAT and will remain registered."
-    }
-
-    "have the correct second h2" in {
-      elementText("h2:nth-child(3)") shouldBe "What happens next"
-    }
-
-    "have the correct second paragraph" in {
-      elementText("p:nth-child(4)") shouldBe
-        "You can apply to deregister again if your turnover falls below the threshold."
-    }
-
-    "have the correct third fifth paragraph" in {
       elementText("p:nth-child(5)") shouldBe
-        "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
-          "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
-          "giving the reasons why you do not agree with our decision. Write to:"
-    }
-
-    "have the correct fourth paragraph" in {
-      elementText("p:nth-child(6)") shouldBe
         "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(7)") shouldBe "You also have the option to appeal to the tax tribunal " +
+      elementText("p:nth-child(6)") shouldBe "You also have the option to appeal to the tax tribunal " +
         "(opens in a new tab) to request a review of an HMRC decision."
     }
 
     "have a link to appeal to the tax tribunal" in {
-      elementAttributes("p:nth-child(7) > a")(document)("href") shouldBe
+      elementAttributes("a")(document)("href") shouldBe
         "https://www.gov.uk/tax-tribunal/appeal-to-tribunal"
     }
 

--- a/test/views/VatEmailApprovedViewSpec.scala
+++ b/test/views/VatEmailApprovedViewSpec.scala
@@ -26,13 +26,8 @@ class VatEmailApprovedViewSpec extends ViewBaseSpec {
     lazy val view = views.html.vatEmailApproved("email@address.com")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your email address for VAT"
+    "have the correct paragraph" in {
+      elementText("p") shouldBe "Your new email address for VAT is: email@address.com"
     }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "Your new email address for VAT is: email@address.com"
-    }
-
   }
 }

--- a/test/views/VatEmailRejectedViewSpec.scala
+++ b/test/views/VatEmailRejectedViewSpec.scala
@@ -26,25 +26,20 @@ class VatEmailRejectedViewSpec extends ViewBaseSpec {
     lazy val view = views.html.vatEmailRejected()
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected the change of email address for VAT"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "You cannot use the email address supplied."
+      elementText("p:nth-child(1)") shouldBe "You cannot use the email address supplied."
     }
 
     "have the correct second paragraph" in {
-      elementText("p:nth-child(3)") shouldBe
+      elementText("p:nth-child(2)") shouldBe
         "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
           "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
           "giving the reasons why you do not agree with our decision. Write to:"
     }
 
     "have the correct HMRC address as the final paragraph" in {
-      elementText("div > div > p:nth-child(4)") shouldBe
+      elementText("div > div > p:nth-child(3)") shouldBe
         "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
     }
-
   }
 }

--- a/test/views/VatPPOBApprovedViewSpec.scala
+++ b/test/views/VatPPOBApprovedViewSpec.scala
@@ -22,46 +22,27 @@ import org.jsoup.nodes.Document
 
 class VatPPOBApprovedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatPPOBApproved secure message content for a client" should {
+  "Rendering the VatPPOBApproved secure message content" should {
 
-    val viewModel = VatPPOBViewModel("21 Blackjack Street", "Stirchley", Some("Telford"), Some("Shropshire"), None, Some("TF2 5TH"), Some("United Kingdom"))
+    val viewModel = VatPPOBViewModel(
+      "21 Blackjack Street",
+      "Stirchley",
+      Some("Telford"),
+      Some("Shropshire"),
+      None,
+      Some("TF2 5TH"),
+      Some("United Kingdom")
+    )
 
-    lazy val view = views.html.vatPPOBApproved(viewModel, isTransactor = false)
+    lazy val view = views.html.vatPPOBApproved(viewModel)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your principal place of business for VAT"
-    }
-
     "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "Your new principal place of business for VAT is:"
+      elementText("p:nth-child(1)") shouldBe "Your new principal place of business for VAT is:"
     }
 
     "have the correct address" in {
-      elementText("p:nth-child(3)") shouldBe "21 Blackjack Street Stirchley Telford Shropshire TF2 5TH United Kingdom"
+      elementText("p:nth-child(2)") shouldBe "21 Blackjack Street Stirchley Telford Shropshire TF2 5TH United Kingdom"
     }
-
   }
-
-  "Rendering the VatPPOBApproved secure message content for a transactor" should {
-
-    val viewModel = VatPPOBViewModel("21 Blackjack Street", "Stirchley", Some("Telford"), Some("Shropshire"), None, Some("TF2 5TH"), Some("United Kingdom"))
-
-    lazy val view = views.html.vatPPOBApproved(viewModel, isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your principal place of business for VAT"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("p:nth-child(2)") shouldBe "Your new principal place of business for VAT is:"
-    }
-
-    "have the correct address" in {
-      elementText("p:nth-child(3)") shouldBe "21 Blackjack Street Stirchley Telford Shropshire TF2 5TH United Kingdom"
-    }
-
-  }
-
 }

--- a/test/views/VatPPOBRejectedViewSpec.scala
+++ b/test/views/VatPPOBRejectedViewSpec.scala
@@ -21,17 +21,13 @@ import org.jsoup.nodes.Document
 
 class VatPPOBRejectedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatPPOBRejected secure message content for a client" should {
+  "Rendering the VatPPOBRejected secure message content" should {
 
-    lazy val view = views.html.vatPPOBRejected(isTransactor = false)
+    lazy val view = views.html.vatPPOBRejected()
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected the change to your principal place of business for VAT"
-    }
-
     "have the correct first paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(2)") shouldBe
+      elementText("div.grid-row > div > p:nth-child(1)") shouldBe
         "Your principal place of business for VAT cannot be any of these address types:"
     }
 
@@ -48,85 +44,30 @@ class VatPPOBRejectedViewSpec extends ViewBaseSpec {
       elementText("div.grid-row > div > ul > li:nth-child(3)") shouldBe "a ‘care of’ address"
     }
 
-    "have the correct second h2" in {
-      elementText("div.grid-row > div > h2:nth-child(4)") shouldBe "What happens next"
-    }
-
-    "have a link to change business details in manage vat subscription frontend" in {
-      elementAttributes("div.grid-row > div > p:nth-child(5) > a")(document)("href") shouldBe
-        "/vat-through-software/account/change-business-details"
-    }
-
-    "have the correct fourth paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(5)") shouldBe
-        "Change your principal place of business to the address where the business does most of its work. " +
-          "If this is in different locations, use the address where it keeps its business records."
-    }
-
-    "have the correct fifth paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(6)") shouldBe
-        "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
-          "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
-          "giving the reasons why you do not agree with our decision. Write to:"
-    }
-
-    "have the correct HMRC address as the final paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(7)") shouldBe
-        "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
-    }
-  }
-
-  "Rendering the VatPPOBRejected secure message content for a transactor" should {
-
-    lazy val view = views.html.vatPPOBRejected(isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
     "have the correct h2" in {
-      elementText("h2") shouldBe "We have rejected your agent’s change to your principal place of business for VAT"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(2)") shouldBe
-        "Your principal place of business for VAT cannot be any of these address types:"
-    }
-
-    "have the correct first bullet point" in {
-      elementText("div.grid-row > div > ul > li:nth-child(1)") shouldBe
-        "the address of a third-party accountant or tax agent"
-    }
-
-    "have the correct second bullet point" in {
-      elementText("div.grid-row > div > ul > li:nth-child(2)") shouldBe "a PO box address"
-    }
-
-    "have the correct third bullet point" in {
-      elementText("div.grid-row > div > ul > li:nth-child(3)") shouldBe "a ‘care of’ address"
-    }
-
-    "have the correct second h2" in {
-      elementText("div.grid-row > div > h2:nth-child(4)") shouldBe "What happens next"
+      elementText("h2") shouldBe "What happens next"
     }
 
     "have a link to change business details in manage vat subscription frontend" in {
-      elementAttributes("div.grid-row > div > p:nth-child(5) > a")(document)("href") shouldBe
+      elementAttributes("a")(document)("href") shouldBe
         "/vat-through-software/account/change-business-details"
     }
 
     "have the correct fourth paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(5)") shouldBe
+      elementText("div.grid-row > div > p:nth-child(4)") shouldBe
         "Change your principal place of business to the address where the business does most of its work. " +
           "If this is in different locations, use the address where it keeps its business records."
     }
 
     "have the correct fifth paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(6)") shouldBe
+      elementText("div.grid-row > div > p:nth-child(5)") shouldBe
         "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
           "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
           "giving the reasons why you do not agree with our decision. Write to:"
     }
 
     "have the correct HMRC address as the final paragraph" in {
-      elementText("div.grid-row > div > p:nth-child(7)") shouldBe
+      elementText("div.grid-row > div > p:nth-child(6)") shouldBe
         "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
     }
   }

--- a/test/views/VatStaggerApprovedViewSpec.scala
+++ b/test/views/VatStaggerApprovedViewSpec.scala
@@ -21,154 +21,62 @@ import org.jsoup.nodes.Document
 
 class VatStaggerApprovedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatStaggerApproved view for an 'MM' stagger code and client" should {
+  "Rendering the VatStaggerApproved view for an 'MM' stagger code" should {
 
-    lazy val view = views.html.vatStaggerApproved("MM", isTransactor = false)
+    lazy val view = views.html.vatStaggerApproved("MM")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your VAT Return dates"
-    }
-
     "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: Every Month"
+      elementText("p:nth-child(1)") shouldBe "Your new return dates for VAT are: Every Month"
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
+      elementText("p:nth-child(2)") shouldBe "Your new return dates might only take effect from " +
         "your next tax period. Check what returns are currently due to make sure you do not miss any."
     }
   }
 
-  "Rendering the VatStaggerApproved view for an 'MM' stagger code and transactor" should {
+  "Rendering the VatStaggerApproved view for an 'MA' stagger code" should {
 
-    lazy val view = views.html.vatStaggerApproved("MM", isTransactor = true)
+    lazy val view = views.html.vatStaggerApproved("MA")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your VAT Return dates"
-    }
-
     "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: Every Month"
+      elementText("p:nth-child(1)") shouldBe "Your new return dates for VAT are: January, April, July and October"
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
+      elementText("p:nth-child(2)") shouldBe "Your new return dates might only take effect from " +
         "your next tax period. Check what returns are currently due to make sure you do not miss any."
     }
   }
 
-  "Rendering the VatStaggerApproved view for an 'MA' stagger code and client" should {
+  "Rendering the VatStaggerApproved view for an 'MB' stagger code" should {
 
-    lazy val view = views.html.vatStaggerApproved("MA", isTransactor = false)
+    lazy val view = views.html.vatStaggerApproved("MB")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your VAT Return dates"
-    }
-
     "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: January, April, July and October"
+      elementText("p:nth-child(1)") shouldBe "Your new return dates for VAT are: February, May, August and November"
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
+      elementText("p:nth-child(2)") shouldBe "Your new return dates might only take effect from " +
         "your next tax period. Check what returns are currently due to make sure you do not miss any."
     }
   }
 
-  "Rendering the VatStaggerApproved view for an 'MA' stagger code and transactor" should {
+  "Rendering the VatStaggerApproved view for an 'MC' stagger code" should {
 
-    lazy val view = views.html.vatStaggerApproved("MA", isTransactor = true)
+    lazy val view = views.html.vatStaggerApproved("MC")
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your VAT Return dates"
-    }
-
     "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: January, April, July and October"
+      elementText("p:nth-child(1)") shouldBe "Your new return dates for VAT are: March, June, September and December"
     }
 
     "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
-        "your next tax period. Check what returns are currently due to make sure you do not miss any."
-    }
-  }
-
-  "Rendering the VatStaggerApproved view for an 'MB' stagger code and client" should {
-
-    lazy val view = views.html.vatStaggerApproved("MB", isTransactor = false)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your VAT Return dates"
-    }
-
-    "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: February, May, August and November"
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
-        "your next tax period. Check what returns are currently due to make sure you do not miss any."
-    }
-  }
-
-  "Rendering the VatStaggerApproved view for an 'MB' stagger code and transactor" should {
-
-    lazy val view = views.html.vatStaggerApproved("MB", isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your VAT Return dates"
-    }
-
-    "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: February, May, August and November"
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
-        "your next tax period. Check what returns are currently due to make sure you do not miss any."
-    }
-  }
-
-  "Rendering the VatStaggerApproved view for an 'MC' stagger code and client" should {
-
-    lazy val view = views.html.vatStaggerApproved("MC", isTransactor = false)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "You have successfully changed your VAT Return dates"
-    }
-
-    "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: March, June, September and December"
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
-        "your next tax period. Check what returns are currently due to make sure you do not miss any."
-    }
-  }
-
-  "Rendering the VatStaggerApproved view for an 'MC' stagger code and transactor" should {
-
-    lazy val view = views.html.vatStaggerApproved("MC", isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct h2" in {
-      elementText("h2") shouldBe "Your agent has successfully changed your VAT Return dates"
-    }
-
-    "have the correct new VAT return dates" in {
-      elementText("p:nth-child(2)") shouldBe "Your new return dates for VAT are: March, June, September and December"
-    }
-
-    "have the correct final paragraph" in {
-      elementText("p:nth-child(3)") shouldBe "Your new return dates might only take effect from " +
+      elementText("p:nth-child(2)") shouldBe "Your new return dates might only take effect from " +
         "your next tax period. Check what returns are currently due to make sure you do not miss any."
     }
   }

--- a/test/views/VatStaggerRejectedViewSpec.scala
+++ b/test/views/VatStaggerRejectedViewSpec.scala
@@ -21,62 +21,28 @@ import org.jsoup.nodes.Document
 
 class VatStaggerRejectedViewSpec extends ViewBaseSpec {
 
-  "Rendering the VatStaggerRejected secure message content for a client" should {
+  "Rendering the VatStaggerRejected secure message content" should {
 
-    lazy val view = views.html.vatStaggerRejected(isTransactor = false)
+    lazy val view = views.html.vatStaggerRejected()
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
-    "have the correct first h2" in {
-      elementText("h2:nth-child(1)") shouldBe "We have rejected the change to your business VAT Return dates"
-    }
-
-    "have the correct second h2" in {
-      elementText("h2:nth-child(2)") shouldBe "What happens next"
+    "have the correct h2" in {
+      elementText("h2") shouldBe "What happens next"
     }
 
     "have the correct first paragraph" in {
-      elementText("div > div > p:nth-child(3)") shouldBe "You must continue to submit to your current deadlines."
+      elementText("div > div > p:nth-child(2)") shouldBe "You must continue to submit to your current deadlines."
     }
 
     "have the correct second paragraph" in {
-      elementText("div > div > p:nth-child(4)") shouldBe
+      elementText("div > div > p:nth-child(3)") shouldBe
         "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
           "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
           "giving the reasons why you do not agree with our decision. Write to:"
     }
 
     "have the correct HMRC address as the final paragraph" in {
-      elementText("div > div > p:nth-child(5)") shouldBe
-        "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
-    }
-  }
-
-  "Rendering the VatStaggerRejected secure message content for a transactor" should {
-
-    lazy val view = views.html.vatStaggerRejected(isTransactor = true)
-    lazy implicit val document: Document = Jsoup.parse(view.body)
-
-    "have the correct first h2" in {
-      elementText("h2:nth-child(1)") shouldBe "We have rejected your agent’s change to your business VAT Return dates"
-    }
-
-    "have the correct second h2" in {
-      elementText("h2:nth-child(2)") shouldBe "What happens next"
-    }
-
-    "have the correct first paragraph" in {
-      elementText("div > div > p:nth-child(3)") shouldBe "You must continue to submit to your current deadlines."
-    }
-
-    "have the correct second paragraph" in {
       elementText("div > div > p:nth-child(4)") shouldBe
-        "If you do not agree with our decision, you can ask for a review by an HMRC officer not previously involved " +
-          "in the matter. If you want a review, you should write to us within 30 days of receiving this message " +
-          "giving the reasons why you do not agree with our decision. Write to:"
-    }
-
-    "have the correct HMRC address as the final paragraph" in {
-      elementText("div > div > p:nth-child(5)") shouldBe
         "HMRC VAT Registration Service Crown House Birch Street WOLVERHAMPTON WV1 4JX"
     }
   }


### PR DESCRIPTION
After speaking to Dale, he has agreed that the "What happens next" headings present in some of the messages should be changed to "heading-small" to match the subject heading text size that the secure comms service insert.