### PR TITLE
BTAT-5484 Updated dependencies and fixed deprecated warnings

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -24,6 +24,8 @@ import config.{ConfigKeys => Keys}
 
 @ImplementedBy(classOf[MicroserviceAppConfig])
 trait AppConfig extends ServicesConfig {
+  val configuration: Configuration
+
   val retryIntervalMillis: Long
 
   def sendSecureCommsMessageUrl(service: String, regNumber: String, communicationId: String): String
@@ -47,6 +49,7 @@ trait AppConfig extends ServicesConfig {
 class MicroserviceAppConfig @Inject()(val runModeConfiguration: Configuration, environment: Environment)
   extends AppConfig {
 
+  override val configuration: Configuration = runModeConfiguration
   override def mode: Mode.Mode = environment.mode
 
   override lazy val retryIntervalMillis: Long = runModeConfiguration.getMilliseconds(Keys.failureRetryAfterProperty)

--- a/app/repositories/CommsEventQueueRepository.scala
+++ b/app/repositories/CommsEventQueueRepository.scala
@@ -35,7 +35,9 @@ class CommsEventQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoCom
   extends WorkItemRepository[VatChangeEvent, BSONObjectID](
     "CommsEventQueue",
     reactiveMongoComponent.mongoConnector.db,
-    WorkItem.workItemMongoFormat[VatChangeEvent]) {
+    WorkItem.workItemMongoFormat[VatChangeEvent],
+    appConfig.configuration.underlying
+  ) {
 
   lazy override val inProgressRetryAfterProperty: String = ConfigKeys.failureRetryAfterProperty
 
@@ -60,6 +62,6 @@ class CommsEventQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoCom
   def complete(id: BSONObjectID)(implicit ec: ExecutionContext): Future[Boolean] = {
     val selector = JsObject(
       Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> Json.toJson(InProgress)))
-    collection.remove(selector).map(_.n > 0)
+    collection.delete().one(selector).map(_.n > 0)
   }
 }

--- a/app/repositories/EmailMessageQueueRepository.scala
+++ b/app/repositories/EmailMessageQueueRepository.scala
@@ -35,7 +35,8 @@ class EmailMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoC
   extends WorkItemRepository[SecureCommsMessageModel, BSONObjectID](
     "EmailMessageQueue",
     reactiveMongoComponent.mongoConnector.db,
-    WorkItem.workItemMongoFormat[SecureCommsMessageModel]
+    WorkItem.workItemMongoFormat[SecureCommsMessageModel],
+    appConfig.configuration.underlying
   ) {
 
   override val inProgressRetryAfterProperty: String = ConfigKeys.failureRetryAfterProperty
@@ -63,6 +64,6 @@ class EmailMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoC
   def complete(id: BSONObjectID)(implicit ec: ExecutionContext): Future[Boolean] = {
     val selector = JsObject(
       Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> Json.toJson(InProgress)))
-    collection.remove(selector).map(_.n > 0)
+    collection.delete().one(selector).map(_.n > 0)
   }
 }

--- a/app/repositories/SecureMessageQueueRepository.scala
+++ b/app/repositories/SecureMessageQueueRepository.scala
@@ -35,7 +35,8 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongo
   extends WorkItemRepository[SecureCommsMessageModel, BSONObjectID](
     "SecureMessageQueue",
     reactiveMongoComponent.mongoConnector.db,
-    WorkItem.workItemMongoFormat[SecureCommsMessageModel]
+    WorkItem.workItemMongoFormat[SecureCommsMessageModel],
+    appConfig.configuration.underlying
   ) {
 
   override val inProgressRetryAfterProperty: String = ConfigKeys.failureRetryAfterProperty
@@ -63,6 +64,6 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongo
   def complete(id: BSONObjectID)(implicit ec: ExecutionContext): Future[Boolean] = {
     val selector = JsObject(
       Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> Json.toJson(InProgress)))
-    collection.remove(selector).map(_.n > 0)
+    collection.delete().one(selector).map(_.n > 0)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -28,22 +28,22 @@ lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 val compile = Seq(
   ws,
   "uk.gov.hmrc" %% "play-reactivemongo" % "6.4.0",
-  "uk.gov.hmrc" %% "work-item-repo"     % "5.2.0",
+  "uk.gov.hmrc" %% "work-item-repo"     % "6.6.0-play-25",
   "uk.gov.hmrc" %% "bootstrap-play-25"  % "4.9.0",
-  "uk.gov.hmrc" %% "play-scheduling"    % "4.1.0"
+  "uk.gov.hmrc" %% "play-scheduling"    % "5.4.0"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
   "uk.gov.hmrc"            %% "hmrctest"                     % "3.3.0"             % scope,
-  "org.scalatest"          %% "scalatest"                    % "3.0.5"             % scope,
+  "org.scalatest"          %% "scalatest"                    % "3.0.6"             % scope,
   "com.typesafe.play"      %% "play-test"                    % PlayVersion.current % scope,
   "org.pegdown"            %  "pegdown"                      % "1.6.0"             % scope,
   "org.scalatestplus.play" %% "scalatestplus-play"           % "2.0.1"             % scope,
   "com.github.tomakehurst" %  "wiremock"                     % "2.21.0"            % scope,
-  "org.mockito"            %  "mockito-core"                 % "2.24.0"            % scope,
+  "org.mockito"            %  "mockito-core"                 % "2.24.5"            % scope,
   "org.scalacheck"         %% "scalacheck"                   % "1.14.0"            % scope,
   "org.scalamock"          %% "scalamock-scalatest-support"  % "3.6.0"             % scope,
-  "uk.gov.hmrc"            %% "reactivemongo-test"           % "3.1.0"             % scope,
+  "uk.gov.hmrc"            %% "reactivemongo-test"           % "4.9.0-play-25"     % scope,
   "org.jsoup"              %  "jsoup"                        % "1.11.3"            % scope
 
 

--- a/test/base/BaseSpec.scala
+++ b/test/base/BaseSpec.scala
@@ -32,7 +32,7 @@ import scala.concurrent.ExecutionContext
 trait BaseSpec extends UnitSpec with GuiceOneAppPerSuite {
   implicit override lazy val app: Application = new GuiceApplicationBuilder().disable[SchedulerModule].build
   val injector: Injector = app.injector
-  implicit val mockAppConfig = new MockAppConfig(app.configuration)
+  implicit val mockAppConfig: MockAppConfig = new MockAppConfig(app.configuration)
   val request = FakeRequest()
 
   implicit val materializer: Materializer = app.materializer

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -24,6 +24,8 @@ class MockAppConfig(val runModeConfiguration: Configuration,
                     val mode: Mode = Mode.Test,
                     override val pollingToggle: Boolean = false) extends AppConfig {
 
+  override val configuration: Configuration = runModeConfiguration
+
   def sendSecureCommsMessageUrl(service: String, regNumber: String, communicationId: String): String =
     s"/secure-comms-alert/service/$service/registration-number/$regNumber/communications/$communicationId"
   override val desAuthorisationToken: String = "EYAUE_AISOD92834894"

--- a/test/services/CommsEventQueuePollingServiceSpec.scala
+++ b/test/services/CommsEventQueuePollingServiceSpec.scala
@@ -23,7 +23,7 @@ import mocks.MockAppConfig
 import models.VatChangeEvent
 import org.mockito.Mockito
 import org.mockito.Mockito.{timeout, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 
 import scala.concurrent.Future

--- a/test/services/CommsEventServiceSpec.scala
+++ b/test/services/CommsEventServiceSpec.scala
@@ -25,7 +25,7 @@ import repositories.CommsEventQueueRepository
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.workitem.{InProgress, WorkItem}
 import utils.SecureCommsMessageTestData.Responses._

--- a/test/services/EmailMessageQueuePollingServiceSpec.scala
+++ b/test/services/EmailMessageQueuePollingServiceSpec.scala
@@ -22,7 +22,7 @@ import mocks.MockAppConfig
 import models.SecureCommsMessageModel
 import org.mockito.Mockito
 import org.mockito.Mockito.{timeout, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import utils.SecureCommsMessageTestData.Responses
 

--- a/test/services/EmailMessageServiceSpec.scala
+++ b/test/services/EmailMessageServiceSpec.scala
@@ -24,7 +24,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.ACCEPTED
 import reactivemongo.bson.BSONObjectID
 import repositories.EmailMessageQueueRepository

--- a/test/services/SecureMessageQueuePollingServiceSpec.scala
+++ b/test/services/SecureMessageQueuePollingServiceSpec.scala
@@ -22,7 +22,7 @@ import mocks.MockAppConfig
 import models.SecureCommsMessageModel
 import org.mockito.Mockito
 import org.mockito.Mockito.{timeout, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import utils.SecureCommsMessageTestData.Responses.expectedResponsePPOBChange
 

--- a/test/services/SecureMessageServiceSpec.scala
+++ b/test/services/SecureMessageServiceSpec.scala
@@ -24,7 +24,7 @@ import repositories.SecureMessageQueueRepository
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.workitem.{InProgress, WorkItem}
 import utils.SecureCommsMessageTestData.SendSecureMessageModels._

--- a/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
+++ b/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
@@ -18,7 +18,7 @@ package testOnly.controllers
 
 import base.BaseSpec
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.CommsEventQueueRepository
 import services.CommsEventQueuePollingService

--- a/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
@@ -18,7 +18,7 @@ package testOnly.controllers
 
 import base.BaseSpec
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.EmailMessageQueueRepository
 import services.EmailMessageQueuePollingService

--- a/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
@@ -18,7 +18,7 @@ package testOnly.controllers
 
 import base.BaseSpec
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
 import repositories.SecureMessageQueueRepository
 import services.SecureMessageQueuePollingService


### PR DESCRIPTION
I am unable to upgrade `play-scheduling` to the latest major version (6.0.0) without encountering mongo issues when running the tests. I saw that other people in the community-mongo Slack channel who had recently encountered the same issue and no solution was proposed.