### PR TITLE
BTAT-5556 Updated the way extra HTTP headers are passed to API#2 GET call

### DIFF
--- a/app/connectors/SecureCommsAlertConnector.scala
+++ b/app/connectors/SecureCommsAlertConnector.scala
@@ -51,13 +51,13 @@ class SecureCommsAlertConnector @Inject()(httpClient: HttpClient,
   def getSecureCommsMessage(service: String, regNumber: String, communicationId: String)
                            (implicit ec: ExecutionContext): Future[SecureCommsAlertResponse] = {
 
-    implicit val hc: HeaderCarrier = HeaderCarrier(Some(Authorization(s"Bearer ${appConfig.desAuthorisationToken}")))
-
-    val requestHeaders: Seq[(String, String)] =
-      hc.withExtraHeaders("Environment" -> appConfig.desEnvironment).headers
-
+    implicit val hc: HeaderCarrier = HeaderCarrier(
+      authorization = Some(Authorization(s"Bearer ${appConfig.desAuthorisationToken}")),
+      extraHeaders = Seq("Environment" -> appConfig.desEnvironment)
+    )
     val url = appConfig.sendSecureCommsMessageUrl(service, regNumber, communicationId)
-    httpClient.GET[SecureCommsAlertResponse](url, queryParams = Seq.empty, headers = requestHeaders).map { response =>
+
+    httpClient.GET[SecureCommsAlertResponse](url).map { response =>
       logWarnEitherError(response)
     }
   }


### PR DESCRIPTION
After the recent refactor to use `HttpClient` over `WsClient`, it looks as though the current way we are passing in extra headers to the API#2 GET call causes a problem where it calls an incorrect host URL (it adds `.service` to the end of the host instead of the `.protected.mdtp` that we want).

I got this information from this SUP ticket where another person had experienced the same issue: https://jira.tools.tax.service.gov.uk/browse/SUP-9917