### PR TITLE
BTAT-9694 Play 2.8 upgrade

### DIFF
--- a/app/connectors/EmailConnector.scala
+++ b/app/connectors/EmailConnector.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import config.AppConfig
+
 import javax.inject.Inject
 import models.emailRendererModels.EmailRequestModel
 import models.responseModels.EmailRendererResponseModel
@@ -24,11 +25,11 @@ import models.{BadRequest, ErrorModel, NotFoundNoMatch}
 import play.api.http.Status._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.http.HttpClient
-import utils.LoggerUtil.logWarnEitherError
+import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailConnector @Inject()(httpClient: HttpClient, appConfig: AppConfig) {
+class EmailConnector @Inject()(httpClient: HttpClient, appConfig: AppConfig) extends LoggerUtil {
 
   type EmailResponse = Either[ErrorModel, EmailRendererResponseModel]
 

--- a/app/connectors/SecureCommsAlertConnector.scala
+++ b/app/connectors/SecureCommsAlertConnector.scala
@@ -23,12 +23,12 @@ import models.responseModels.SecureCommsResponseModel
 import play.api.http.Status._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
-import utils.LoggerUtil._
+import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SecureCommsAlertConnector @Inject()(httpClient: HttpClient,
-                                          appConfig: AppConfig) {
+                                          appConfig: AppConfig) extends LoggerUtil {
 
   type SecureCommsAlertResponse = Either[ErrorModel, SecureCommsResponseModel]
 
@@ -40,7 +40,7 @@ class SecureCommsAlertConnector @Inject()(httpClient: HttpClient,
         case BAD_REQUEST => handleBadRequest(response)
         case NOT_FOUND => handleNotFound(response)
         case status: Int =>
-          logWarn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
+          logger.warn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
             s"Unexpected error encountered. Status: '$status', Body: '${response.body}'")
           Left(ErrorModel(s"${response.status}", response.body))
       }
@@ -63,23 +63,23 @@ class SecureCommsAlertConnector @Inject()(httpClient: HttpClient,
   private def handleOk(response: HttpResponse): SecureCommsAlertResponse =
     Json.parse(response.body).validate[SecureCommsResponseModel].asOpt match {
       case Some(responseModel) =>
-        logDebug("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
+        logger.debug("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
           s"Successfully parsed SecureCommsResponseModel: $responseModel")
         Right(responseModel)
       case None =>
-        logWarn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
+        logger.warn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
           "Failed to validate response to SecureCommsResponseModel")
-        logDebug(s"[SecureCommsAlertConnector][getSecureCommsMessage] - Body: '${response.body}'")
+        logger.debug(s"[SecureCommsAlertConnector][getSecureCommsMessage] - Body: '${response.body}'")
         Left(GenericParsingError)
     }
 
   private def handleBadRequest(response: HttpResponse): Left[ErrorModel, SecureCommsResponseModel] = {
-    logWarn(s"[SecureCommsAlertConnector][getSecureCommsMessage] - Bad request. Body: '${response.body}'")
+    logger.warn(s"[SecureCommsAlertConnector][getSecureCommsMessage] - Bad request. Body: '${response.body}'")
     Left(BadRequest)
   }
 
   private def handleNotFound(response: HttpResponse): Left[ErrorModel, SecureCommsResponseModel] = {
-    logWarn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
+    logger.warn("[SecureCommsAlertConnector][getSecureCommsMessage] - " +
       s"The requested data was not found. Body: '${response.body}'")
     Left(NotFoundNoMatch)
   }

--- a/app/connectors/SecureCommsServiceConnector.scala
+++ b/app/connectors/SecureCommsServiceConnector.scala
@@ -17,17 +17,18 @@
 package connectors
 
 import config.AppConfig
+
 import javax.inject.Inject
 import models._
 import models.secureCommsServiceModels.SecureCommsServiceRequestModel
 import play.api.http.Status._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.http.HttpClient
-import utils.LoggerUtil.{logWarn, logWarnEitherError}
+import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SecureCommsServiceConnector @Inject()(httpClient: HttpClient, appConfig: AppConfig) {
+class SecureCommsServiceConnector @Inject()(httpClient: HttpClient, appConfig: AppConfig) extends LoggerUtil {
 
   type SecureCommsResponse = Either[ErrorModel, Boolean]
 
@@ -37,7 +38,7 @@ class SecureCommsServiceConnector @Inject()(httpClient: HttpClient, appConfig: A
       response.status match {
         case CREATED => Right(true)
         case BAD_REQUEST =>
-          logWarn(s"[SendMessageReads][read] - Bad request received from Secure Comms service: ${response.body}")
+          logger.warn(s"[SendMessageReads][read] - Bad request received from Secure Comms service: ${response.body}")
           Left(BadRequest)
         case CONFLICT => Left(ConflictDuplicateMessage)
         case otherStatus => Left(ErrorModel(s"${otherStatus}_RECEIVED_FROM_SERVICE", response.body))

--- a/app/controllers/BankAccountController.scala
+++ b/app/controllers/BankAccountController.scala
@@ -21,15 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class BankAccountController @Inject()(repoAccess: CommsEventService)
-                                     (implicit val ec: ExecutionContext, cc: ControllerComponents)
-                                      extends BackendController(cc) with MicroserviceBaseController {
+class BankAccountController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                     (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -38,7 +35,7 @@ class BankAccountController @Inject()(repoAccess: CommsEventService)
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[BankAccountController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[BankAccountController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/BusinessNameController.scala
+++ b/app/controllers/BusinessNameController.scala
@@ -20,13 +20,10 @@ import javax.inject.Inject
 import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import scala.concurrent.ExecutionContext
 import scala.util.Right
 
-class BusinessNameController @Inject()()(implicit val ec: ExecutionContext, cc: ControllerComponents) extends
-                                        BackendController(cc) with MicroserviceBaseController {
+class BusinessNameController @Inject()(cc: ControllerComponents) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action { implicit request =>
     parseJsonBody[VatChangeEvent] match {

--- a/app/controllers/ContactNumbersController.scala
+++ b/app/controllers/ContactNumbersController.scala
@@ -21,15 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class ContactNumbersController @Inject()(repoAccess: CommsEventService)
-                                        (implicit val ec: ExecutionContext, cc: ControllerComponents) extends
-                                        BackendController(cc) with MicroserviceBaseController {
+class ContactNumbersController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                        (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -38,7 +35,7 @@ class ContactNumbersController @Inject()(repoAccess: CommsEventService)
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[ContactNumbersController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[ContactNumbersController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/DeregistrationController.scala
+++ b/app/controllers/DeregistrationController.scala
@@ -21,15 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class DeregistrationController @Inject()(repoAccess: CommsEventService)
-                                        (implicit val ec: ExecutionContext, cc: ControllerComponents) extends
-                                        BackendController(cc) with MicroserviceBaseController {
+class DeregistrationController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                        (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -38,7 +35,8 @@ class DeregistrationController @Inject()(repoAccess: CommsEventService)
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[DeregistrationController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(
+              s"[DeregistrationController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -21,14 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class EmailController @Inject()(repoAccess: CommsEventService)
-                               (implicit val ec: ExecutionContext, cc: ControllerComponents) extends BackendController(cc) with MicroserviceBaseController {
+class EmailController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                               (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -37,7 +35,7 @@ class EmailController @Inject()(repoAccess: CommsEventService)
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[EmailController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[EmailController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/MicroserviceBaseController.scala
+++ b/app/controllers/MicroserviceBaseController.scala
@@ -18,24 +18,24 @@ package controllers
 
 import models.ErrorModel
 import play.api.libs.json.{JsError, JsSuccess, Reads}
-import play.api.mvc.{AnyContentAsJson, Request}
+import play.api.mvc.{AnyContentAsJson, ControllerComponents, Request}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil.{logDebug, logWarn}
+import utils.LoggerUtil
 
-trait MicroserviceBaseController extends BackendController {
+abstract class MicroserviceBaseController(cc: ControllerComponents) extends BackendController(cc) with LoggerUtil {
 
   def parseJsonBody[T](implicit request: Request[_], rds: Reads[T]): Either[ErrorModel, T] = request.body match {
     case body: AnyContentAsJson => body.json.validate[T] match {
       case e: JsError =>
-        logDebug(s"[MicroserviceBaseController][parseJsonBody] Json received, but did not validate. Errors: $e")
-        logWarn(s"[MicroserviceBaseController][parseJsonBody] Json received, but did not validate.")
+        logger.debug(s"[MicroserviceBaseController][parseJsonBody] Json received, but did not validate. Errors: $e")
+        logger.warn(s"[MicroserviceBaseController][parseJsonBody] Json received, but did not validate.")
         Left(ErrorModel("INVALID_JSON", "Json received, but did not validate"))
       case s: JsSuccess[T] =>
         Right(s.value)
     }
     case _ =>
-      logDebug(s"[MicroserviceBaseController][parseJsonBody] Body of request was not JSON. Request body received:'${request.body}'")
-      logWarn(s"[MicroserviceBaseController][parseJsonBody] Body of request was not JSON.")
+      logger.debug(s"[MicroserviceBaseController][parseJsonBody] Body of request was not JSON. Request body received:'${request.body}'")
+      logger.warn(s"[MicroserviceBaseController][parseJsonBody] Body of request was not JSON.")
       Left(ErrorModel("INVALID_FORMAT", s"Request body was not JSON."))
   }
 }

--- a/app/controllers/OptOutController.scala
+++ b/app/controllers/OptOutController.scala
@@ -21,14 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class OptOutController @Inject()(repoAccess: CommsEventService)(implicit val ec: ExecutionContext, cc: ControllerComponents) extends
-                                                                BackendController(cc) with MicroserviceBaseController {
+class OptOutController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -37,7 +35,7 @@ class OptOutController @Inject()(repoAccess: CommsEventService)(implicit val ec:
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[OptOutController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[OptOutController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/PPOBController.scala
+++ b/app/controllers/PPOBController.scala
@@ -21,14 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class PPOBController @Inject()(repoAccess: CommsEventService)(implicit val ec: ExecutionContext, cc: ControllerComponents) extends
-                                                              BackendController(cc) with MicroserviceBaseController {
+class PPOBController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                              (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -37,7 +35,7 @@ class PPOBController @Inject()(repoAccess: CommsEventService)(implicit val ec: E
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[PPOBController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[PPOBController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/StaggerController.scala
+++ b/app/controllers/StaggerController.scala
@@ -21,14 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class StaggerController @Inject()(repoAccess: CommsEventService)(implicit val ec: ExecutionContext, cc: ControllerComponents)
-                                                                extends BackendController(cc) with MicroserviceBaseController {
+class StaggerController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                 (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -37,7 +35,7 @@ class StaggerController @Inject()(repoAccess: CommsEventService)(implicit val ec
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[StaggerController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(s"[StaggerController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/controllers/WebAddressController.scala
+++ b/app/controllers/WebAddressController.scala
@@ -21,14 +21,12 @@ import models.VatChangeEvent
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.CommsEventService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class WebAddressController @Inject()(repoAccess: CommsEventService)(implicit val ec: ExecutionContext, cc: ControllerComponents)
-                                                                    extends BackendController(cc) with MicroserviceBaseController {
+class WebAddressController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+                                    (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>
 
@@ -37,7 +35,8 @@ class WebAddressController @Inject()(repoAccess: CommsEventService)(implicit val
         repoAccess.queueRequest(workItem) map {
           case true  => NoContent
           case false =>
-            LoggerUtil.logWarn(s"[WebAddressController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
+            logger.warn(
+              s"[WebAddressController][handleEvent] Unable to add WorkItem to Repository: ${workItem.BPContactNumber}")
             InternalServerError
         }
 

--- a/app/repositories/CommsEventQueueRepository.scala
+++ b/app/repositories/CommsEventQueueRepository.scala
@@ -17,10 +17,11 @@
 package repositories
 
 import config.{AppConfig, ConfigKeys}
+
 import javax.inject.{Inject, Singleton}
 import models.VatChangeEvent
 import org.joda.time.DateTime
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsString, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -28,7 +29,7 @@ import reactivemongo.play.json.ImplicitBSONHandlers._
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem._
-import utils.LoggerUtil.{logDebug, logError}
+import utils.LoggerUtil
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -41,6 +42,8 @@ class CommsEventQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoCom
     WorkItem.workItemMongoFormat[VatChangeEvent],
     appConfig.configuration.underlying
   ) {
+
+  val appLogger: LoggerUtil = new LoggerUtil{}
 
   lazy override val inProgressRetryAfterProperty: String = ConfigKeys.failureRetryAfterProperty
 
@@ -66,11 +69,11 @@ class CommsEventQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoCom
     collection.indexesManager.ensure(Index(Seq((field, IndexType.Ascending)), Some(indexName),
       options = BSONDocument(expireAfterSeconds -> ttl))) map {
       result =>
-        logDebug(s"set [$indexName] with value $ttl -> result : $result")
+        appLogger.logger.debug(s"set [$indexName] with value $ttl -> result : $result")
         result
     } recover {
       case e =>
-        logError("Failed to set TTL index", e)
+        appLogger.logger.error("Failed to set TTL index", e)
         false
     }
   }
@@ -84,7 +87,7 @@ class CommsEventQueueRepository @Inject()(appConfig: AppConfig, reactiveMongoCom
 
   def complete(id: BSONObjectID): Future[Boolean] = {
     val selector = JsObject(
-      Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> Json.toJson(InProgress)))
+      Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> JsString(InProgress.name)))
     collection.delete().one(selector).map(_.n > 0)
   }
 }

--- a/app/repositories/SecureMessageQueueRepository.scala
+++ b/app/repositories/SecureMessageQueueRepository.scala
@@ -17,10 +17,11 @@
 package repositories
 
 import config.{AppConfig, ConfigKeys}
+
 import javax.inject.{Inject, Singleton}
 import models.SecureCommsMessageModel
 import org.joda.time.{DateTime, Duration}
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsString, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -28,7 +29,7 @@ import reactivemongo.play.json.ImplicitBSONHandlers._
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem.{InProgress, WorkItem, WorkItemFieldNames, WorkItemRepository}
-import utils.LoggerUtil.{logDebug, logError}
+import utils.LoggerUtil
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -41,6 +42,8 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongo
     WorkItem.workItemMongoFormat[SecureCommsMessageModel],
     appConfig.configuration.underlying
   ) {
+
+  val appLogger: LoggerUtil = new LoggerUtil{}
 
   override val inProgressRetryAfterProperty: String = ConfigKeys.failureRetryAfterProperty
 
@@ -66,11 +69,11 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongo
     collection.indexesManager.ensure(Index(Seq((field, IndexType.Ascending)), Some(indexName),
       options = BSONDocument(expireAfterSeconds -> ttl))) map {
       result =>
-        logDebug(s"set [$indexName] with value $ttl -> result : $result")
+        appLogger.logger.debug(s"set [$indexName] with value $ttl -> result : $result")
         result
     } recover {
       case e =>
-        logError("Failed to set TTL index", e)
+        appLogger.logger.error("Failed to set TTL index", e)
         false
     }
   }
@@ -86,7 +89,7 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, reactiveMongo
 
   def complete(id: BSONObjectID): Future[Boolean] = {
     val selector = JsObject(
-      Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> Json.toJson(InProgress)))
+      Seq("_id" -> Json.toJson(id)(ReactiveMongoFormats.objectIdFormats), "status" -> JsString(InProgress.name)))
     collection.delete().one(selector).map(_.n > 0)
   }
 }

--- a/app/services/CommsEventQueuePollingService.scala
+++ b/app/services/CommsEventQueuePollingService.scala
@@ -19,8 +19,8 @@ package services
 import akka.actor.ActorSystem
 import com.google.inject.{Inject, Singleton}
 import config.AppConfig
-import uk.gov.hmrc.play.scheduling.ExclusiveScheduledJob
-import utils.LoggerUtil._
+import utils.ExclusiveScheduledJob
+import utils.LoggerUtil
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,26 +30,26 @@ import scala.util.{Failure, Success}
 class CommsEventQueuePollingService @Inject()(actorSystem: ActorSystem,
                                               appConfig: AppConfig,
                                               commsEventService: CommsEventService)(
-                                              implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
+                                              implicit ec: ExecutionContext) extends ExclusiveScheduledJob with LoggerUtil {
 
   override def name: String = "CommsEventQueuePollingService"
 
   override def executeInMutex(implicit ec: ExecutionContext): Future[Result] =
     commsEventService.retrieveWorkItems.map(items => Result(s"Processed ${items.size} comms events"))
 
-  lazy val initialDelay: FiniteDuration = appConfig.initialWaitTime.seconds
-  lazy val interval: FiniteDuration = appConfig.queuePollingWaitTime.seconds
+  override def initialDelay: FiniteDuration = appConfig.initialWaitTime.seconds
+  override def interval: FiniteDuration = appConfig.queuePollingWaitTime.seconds
 
-  logInfo(s"Starting comms event queue scheduler." +
+  logger.info(s"Starting comms event queue scheduler." +
     s"\nInitial delay: $initialDelay" +
     s"\nPolling interval: $interval")
 
   def executor()(implicit ec: ExecutionContext): Unit = {
     execute.onComplete({
-      case Success(Result(_)) =>
-        logInfo(_)
+      case Success(Result(message)) =>
+        logger.info(message)
       case Failure(throwable) =>
-        logWarn(s"Exception completing work item", throwable)
+        logger.warn(s"Exception completing work item", throwable)
     })
   }
 
@@ -57,7 +57,7 @@ class CommsEventQueuePollingService @Inject()(actorSystem: ActorSystem,
     if (appConfig.pollingToggle) {
       executor()
     } else {
-      logInfo("Polling is toggled off")
+      logger.info("Polling is toggled off")
     }
   }
 }

--- a/app/services/EmailMessageQueuePollingService.scala
+++ b/app/services/EmailMessageQueuePollingService.scala
@@ -19,8 +19,8 @@ package services
 import akka.actor.ActorSystem
 import com.google.inject.{Inject, Singleton}
 import config.AppConfig
-import uk.gov.hmrc.play.scheduling.ExclusiveScheduledJob
-import utils.LoggerUtil._
+import utils.ExclusiveScheduledJob
+import utils.LoggerUtil
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,26 +30,26 @@ import scala.util.{Failure, Success}
 class EmailMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
                                                 appConfig: AppConfig,
                                                 emailMessageService: EmailMessageService)
-                                                (implicit ec: ExecutionContext) extends ExclusiveScheduledJob {
+                                                (implicit ec: ExecutionContext) extends ExclusiveScheduledJob with LoggerUtil {
 
   override def name: String = "EmailMessageQueuePollingService"
 
   override def executeInMutex(implicit ec: ExecutionContext): Future[Result] =
     emailMessageService.retrieveWorkItems.map(items => Result(s"Processed ${items.size} email items"))
 
-  lazy val initialDelay: FiniteDuration = appConfig.initialWaitTime.seconds
-  lazy val interval: FiniteDuration = appConfig.queuePollingWaitTime.seconds
+  override def initialDelay: FiniteDuration = appConfig.initialWaitTime.seconds
+  override def interval: FiniteDuration = appConfig.queuePollingWaitTime.seconds
 
-  logInfo(s"Starting email message queue scheduler." +
+  logger.info(s"Starting email message queue scheduler." +
     s"\nInitial delay: $initialDelay" +
     s"\nPolling interval: $interval")
 
   def executor()(implicit ec: ExecutionContext): Unit = {
     execute.onComplete({
-      case Success(Result(_)) =>
-        logInfo(_)
+      case Success(Result(message)) =>
+        logger.info(message)
       case Failure(throwable) =>
-        logError(s"Exception completing work item", throwable)
+        logger.error(s"Exception completing work item", throwable)
     })
   }
 
@@ -57,7 +57,7 @@ class EmailMessageQueuePollingService @Inject()(actorSystem: ActorSystem,
     if (appConfig.pollingToggle) {
       executor()
     } else {
-      logInfo("Polling is toggled off")
+      logger.info("Polling is toggled off")
     }
   }
 }

--- a/app/services/EmailMessageService.scala
+++ b/app/services/EmailMessageService.scala
@@ -23,15 +23,14 @@ import play.api.libs.iteratee.{Enumerator, Iteratee}
 import repositories.EmailMessageQueueRepository
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem.{Failed, PermanentlyFailed, WorkItem}
-import utils.LoggerUtil.{logError, logWarn}
-import utils.SecureCommsMessageParser
+import utils.{LoggerUtil, SecureCommsMessageParser}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQueueRepository,
                                     emailService: EmailService,
                                     metrics: QueueMetrics)(
-                                    implicit ec: ExecutionContext) {
+                                    implicit ec: ExecutionContext) extends LoggerUtil {
 
   def queueRequest(item: SecureCommsMessageModel): Future[Boolean] = {
     metrics.emailMessageEnqueued()
@@ -89,8 +88,8 @@ class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQue
       s"${workItem.item.vrn}, form bundle ref: ${workItem.item.formBundleReference} and work item id: ${workItem.id}"
 
     exception match {
-      case Some(error) => logError(message, error)
-      case None => logWarn(message)
+      case Some(error) => logger.error(message, error)
+      case None => logger.warn(message)
     }
 
     emailMessageQueueRepository.markAs(workItem.id, PermanentlyFailed, None).map(_ => acc)

--- a/app/services/SecureCommsAlertService.scala
+++ b/app/services/SecureCommsAlertService.scala
@@ -17,14 +17,14 @@
 package services
 
 import connectors.SecureCommsAlertConnector
+
 import javax.inject.Inject
 import models.{ErrorModel, GenericParsingError, JsonParsingError, SecureCommsMessageModel}
-import utils.LoggerUtil.logWarn
-import utils.SecureCommsMessageParser
+import utils.{LoggerUtil, SecureCommsMessageParser}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SecureCommsAlertService @Inject()(secureCommsAlertConnector: SecureCommsAlertConnector) {
+class SecureCommsAlertService @Inject()(secureCommsAlertConnector: SecureCommsAlertConnector) extends LoggerUtil {
 
   def getSecureCommsMessage(service: String, regNumber: String, communicationId: String)
                            (implicit ec: ExecutionContext): Future[Either[ErrorModel, SecureCommsMessageModel]] =
@@ -33,7 +33,7 @@ class SecureCommsAlertService @Inject()(secureCommsAlertConnector: SecureCommsAl
         case Right(parsedJson) => parsedJson.validate[SecureCommsMessageModel].asOpt match {
           case Some(parsedModel) => Right(parsedModel)
           case None =>
-            logWarn(s"[SecureCommsAlertService][getSecureCommsMessage] - " +
+            logger.warn(s"[SecureCommsAlertService][getSecureCommsMessage] - " +
               s"${GenericParsingError.code} => ${GenericParsingError.body}")
             Left(GenericParsingError)
         }

--- a/app/services/SecureCommsService.scala
+++ b/app/services/SecureCommsService.scala
@@ -31,11 +31,8 @@ import models.secureMessageAlertModels.messageTypes._
 import models.viewModels.VatPPOBViewModel
 import models.{ErrorModel, GenericQueueNoRetryError, SecureCommsMessageModel, SpecificParsingError}
 import play.api.i18n._
-import play.api.mvc.ControllerComponents
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.Base64Encoding._
 import utils.DateFormatter._
-import utils.LoggerUtil.logWarn
 import utils.SecureCommsMessageParser._
 import utils.TemplateMappings._
 import views.html._
@@ -52,8 +49,7 @@ class SecureCommsService @Inject()(secureCommsServiceConnector: SecureCommsServi
                                    vatOptOutApprovedRepresented: VatOptOutApprovedRepresented, vatOptOutApproved: VatOptOutApproved,
                                    vatContactNumbersApproved: VatContactNumbersApproved, vatContactNumbersRejected: VatContactNumbersRejected,
                                    vatWebsiteApproved: VatWebsiteApproved, vatWebsiteRejected: VatWebsiteRejected)
-                                  (implicit val appConfig: AppConfig, cc: ControllerComponents, messagesApi: MessagesApi) extends
-  BackendController(cc) with I18nSupport {
+                                  (implicit val appConfig: AppConfig, val messagesApi: MessagesApi) extends I18nSupport {
 
   val lang: Lang = new Lang(ENGLISH)
 
@@ -81,7 +77,7 @@ class SecureCommsService @Inject()(secureCommsServiceConnector: SecureCommsServi
 
     isTemplateIdApproval(messageModel.getTemplateId) match {
       case None =>
-        logWarn(content = s"[SecureCommsService][getRequest] - Unexpected Template Id encountered:  ${messageModel.getTemplateId}")
+        logger.warn(s"[SecureCommsService][getRequest] - Unexpected Template Id encountered:  ${messageModel.getTemplateId}")
         Left(GenericQueueNoRetryError)
       case Some(isApproval) =>
         Right(buildResponse(messageModel, isTransactor, isApproval))
@@ -228,13 +224,13 @@ class SecureCommsService @Inject()(secureCommsServiceConnector: SecureCommsServi
         }
       } catch {
         case exception: DateTimeParseException =>
-          logWarn(s"[SecureCommsService][getStaggerChangeHtml] - Error parsing one of the provided dates.\n" +
+          logger.warn(s"[SecureCommsService][getStaggerChangeHtml] - Error parsing one of the provided dates.\n" +
             s"New stagger start date: ${vatStaggerChangeModel.staggerDetails.newStaggerStartDate}\n" +
             s"New stagger end date: ${vatStaggerChangeModel.staggerDetails.newStaggerPeriodEndDate}\n" +
             s"Prev stagger end date: ${vatStaggerChangeModel.staggerDetails.previousStaggerEndDate}")
           throw exception
         case exception: MatchError =>
-          logWarn("[SecureCommsService][getStaggerChangeHtml] - " +
+          logger.warn("[SecureCommsService][getStaggerChangeHtml] - " +
             s"Unrecognised stagger code: ${vatStaggerChangeModel.staggerDetails.stagger.toUpperCase}")
           throw exception
       }

--- a/app/testOnly/controllers/CommsEventQueueController.scala
+++ b/app/testOnly/controllers/CommsEventQueueController.scala
@@ -21,14 +21,13 @@ import controllers.MicroserviceBaseController
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import repositories.CommsEventQueueRepository
 import services.CommsEventQueuePollingService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class CommsEventQueueController @Inject()(repository: CommsEventQueueRepository,
-                                          scheduler: CommsEventQueuePollingService)(
-                                          implicit ec: ExecutionContext, cc: ControllerComponents)
-                                          extends BackendController(cc) with MicroserviceBaseController {
+                                          scheduler: CommsEventQueuePollingService,
+                                          cc: ControllerComponents)
+                                         (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def count: Action[AnyContent] = Action.async {
     val result: Future[Int] = repository.count

--- a/app/testOnly/controllers/EmailMessageQueueController.scala
+++ b/app/testOnly/controllers/EmailMessageQueueController.scala
@@ -21,14 +21,13 @@ import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import repositories.EmailMessageQueueRepository
 import services.EmailMessageQueuePollingService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class EmailMessageQueueController @Inject()(repository: EmailMessageQueueRepository,
-                                            scheduler: EmailMessageQueuePollingService)(
-                                            implicit ec: ExecutionContext, cc: ControllerComponents)
-                                            extends BackendController(cc) with MicroserviceBaseController {
+                                            scheduler: EmailMessageQueuePollingService,
+                                            cc: ControllerComponents)
+                                           (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def count: Action[AnyContent] = Action.async {
     val result: Future[Int] = repository.count

--- a/app/testOnly/controllers/SecureMessageQueueController.scala
+++ b/app/testOnly/controllers/SecureMessageQueueController.scala
@@ -21,14 +21,13 @@ import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import repositories.SecureMessageQueueRepository
 import services.SecureMessageQueuePollingService
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SecureMessageQueueController @Inject()(repository: SecureMessageQueueRepository,
-                                             scheduler: SecureMessageQueuePollingService)(
-                                             implicit ec: ExecutionContext, cc: ControllerComponents)
-                                            extends BackendController(cc) with MicroserviceBaseController {
+                                             scheduler: SecureMessageQueuePollingService,
+                                             cc: ControllerComponents)
+                                            (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def count: Action[AnyContent] = Action.async {
     val result: Future[Int] = repository.count

--- a/app/utils/ExclusiveScheduledJob.scala
+++ b/app/utils/ExclusiveScheduledJob.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.util.concurrent.Semaphore
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+trait ExclusiveScheduledJob {
+
+  def name: String
+
+  def initialDelay: FiniteDuration
+
+  def interval: FiniteDuration
+
+  case class Result(message: String)
+
+  def executeInMutex(implicit ec: ExecutionContext): Future[this.Result]
+
+  final private val mutex = new Semaphore(1)
+
+  final def execute(implicit ec: ExecutionContext): Future[Result] =
+    if (mutex.tryAcquire()) {
+      Try(executeInMutex) match {
+        case Success(f) => f andThen { case _ => mutex.release() }
+        case Failure(e) => Future.successful(mutex.release()).flatMap(_ => Future.failed(e))
+      }
+    } else {
+      Future.successful(Result("Skipping execution: job running"))
+    }
+
+  def isRunning: Future[Boolean] = Future.successful(mutex.availablePermits() == 0)
+
+  override def toString() = s"$name after $initialDelay every $interval"
+}

--- a/app/utils/LoggerUtil.scala
+++ b/app/utils/LoggerUtil.scala
@@ -17,27 +17,16 @@
 package utils
 
 import models.ErrorModel
-import play.api.Logger
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.LoggerLike
 
-// $COVERAGE-OFF$
-
-object LoggerUtil {
-
-  def logInfo(content: String): Unit = Logger.info(content)
-  def logDebug(content: String): Unit = Logger.debug(content)
-  def logWarn(content: String): Unit = Logger.warn(content)
-  def logWarn(content: String, throwable: Throwable): Unit = Logger.warn(content, throwable)
-  def logError(content: String): Unit = Logger.error(content)
-  def logError(content: String, throwable: Throwable): Unit = Logger.error(content, throwable)
-
+trait LoggerUtil extends LoggerLike {
+  override val logger: Logger = LoggerFactory.getLogger("application")
   def logWarnEitherError[T](content: Either[ErrorModel, T]): Either[ErrorModel, T] = {
     if(content.isLeft) {
       val leftValue = content.left.get
-      logWarn(s"${leftValue.code} => ${leftValue.body}")
+      logger.warn(s"${leftValue.code} => ${leftValue.body}")
     }
     content
   }
-
 }
-
-// $COVERAGE-ON$

--- a/app/utils/SecureCommsMessageParser.scala
+++ b/app/utils/SecureCommsMessageParser.scala
@@ -19,9 +19,8 @@ package utils
 import models._
 import models.secureMessageAlertModels.messageTypes._
 import play.api.libs.json.{JsValue, Json, OFormat}
-import utils.LoggerUtil._
 
-object SecureCommsMessageParser {
+object SecureCommsMessageParser extends LoggerUtil {
   private def convertToCamelCase(inputString: String): String = {
     val allLowerCase = inputString.toLowerCase
       .replace("-", " ")
@@ -43,7 +42,7 @@ object SecureCommsMessageParser {
       Right(Json.toJson(stringAsMap))
     } catch {
       case _: Throwable =>
-        logError("[SecureCommsMessageParser][parseMessage] Error performing generic parse")
+        logger.error("[SecureCommsMessageParser][parseMessage] Error performing generic parse")
         Left(JsonParsingError)
     }
   }
@@ -67,7 +66,7 @@ object SecureCommsMessageParser {
       case x@SecureCommsMessageModel(_, _, _, _, None, None, None, None, None, None, None, Some(_), _, _, _) =>
         Right(toGivenModel[ContactNumbersChangeModel](x))
       case x: SecureCommsMessageModel =>
-        logError("[SecureCommsMessageParser][parseModel] Error parsing generic type into specific type\n" +
+        logger.error("[SecureCommsMessageParser][parseModel] Error parsing generic type into specific type\n" +
           "Populated optional fields:" + generateStringFromOptionalFields(x)
         )
         Left(SpecificParsingError)

--- a/build.sbt
+++ b/build.sbt
@@ -26,23 +26,23 @@ val appName = "mtd-vat-comms"
 lazy val appDependencies: Seq[ModuleID] = compile ++ test() ++ tmpMacWorkaround()
 
 val compile = Seq(
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.29.0-play-26",
-  "uk.gov.hmrc" %% "work-item-repo"       % "7.6.0-play-26",
-  "uk.gov.hmrc" %% "bootstrap-backend-play-26"    % "5.3.0",
-  "uk.gov.hmrc" %% "play-scheduling"      % "7.4.0-play-26"
+  "uk.gov.hmrc" %% "simple-reactivemongo"      % "8.0.0-play-28",
+  "uk.gov.hmrc" %% "work-item-repo"            % "8.1.0-play-28",
+  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.14.0"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc"            %% "hmrctest"                     % "3.9.0-play-26"     % scope,
-  "org.scalatest"          %% "scalatest"                    % "3.0.8"             % scope,
+  "org.scalatest"          %% "scalatest"                    % "3.1.4"             % scope,
   "com.typesafe.play"      %% "play-test"                    % PlayVersion.current % scope,
   "org.pegdown"            %  "pegdown"                      % "1.6.0"             % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play"           % "3.1.0"             % scope,
-  "com.github.tomakehurst" %  "wiremock-jre8"                % "2.27.1"            % scope,
+  "org.scalatestplus.play" %% "scalatestplus-play"           % "5.1.0"             % scope,
+  "org.scalatestplus"      %% "mockito-3-4"                  % "3.2.9.0"           % scope,
+  "com.github.tomakehurst" %  "wiremock-jre8"                % "2.26.3"            % scope,
   "org.mockito"            %  "mockito-core"                 % "2.24.5"            % scope,
   "org.scalacheck"         %% "scalacheck"                   % "1.14.0"            % scope,
   "org.scalamock"          %% "scalamock-scalatest-support"  % "3.6.0"             % scope,
-  "org.jsoup"              %  "jsoup"                        % "1.13.1"            % scope
+  "org.jsoup"              %  "jsoup"                        % "1.13.1"            % scope,
+  "com.vladsch.flexmark"   % "flexmark-all"                  % "0.36.8"            % scope
 )
 
 lazy val coverageSettings: Seq[Setting[_]] = {
@@ -50,24 +50,17 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
   val excludedPackages = Seq(
     "<empty>",
-    "Reverse.*",
-    ".*standardError*.*",
-    ".*govuk_wrapper*.*",
-    ".*main_template*.*",
-    "uk.gov.hmrc.BuildInfo",
+    ".*Reverse.*",
     "app.*",
     "prod.*",
     "config.*",
     "testOnly.*",
-    ".*feedback*.*",
-    "views.html.*",
-    "partials.*",
-    "controllers..*Reverse.*"
+    "views.html.*"
   )
 
   Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimum := 95,
+    ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )
@@ -90,7 +83,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(majorVersion := 0)
   .settings(defaultSettings(): _*)
   .settings(
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.12.14",
     PlayKeys.playDefaultPort := 9579,
     libraryDependencies ++= appDependencies,
     retrieveManaged := true,

--- a/it/connectors/EmailConnectorIT.scala
+++ b/it/connectors/EmailConnectorIT.scala
@@ -22,13 +22,14 @@ import models.emailRendererModels.EmailRequestModel
 import models.responseModels.EmailRendererResponseModel
 import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import testutils.WireMockHelper
 
 class EmailConnectorIT extends IntegrationBaseSpec with WireMockHelper {
 
   val connector: EmailConnector = new EmailConnector(httpClient, appConfig)
   val postUrl: String = "/hmrc/email"
-  val postBody = EmailRequestModel(
+  val postBody: EmailRequestModel = EmailRequestModel(
     Seq("test@email.com"),
     "testId",
     Map("key" -> "value")

--- a/it/connectors/SecureCommsAlertConnectorIT.scala
+++ b/it/connectors/SecureCommsAlertConnectorIT.scala
@@ -20,6 +20,7 @@ import helpers.IntegrationBaseSpec
 import models._
 import models.responseModels.SecureCommsResponseModel
 import play.api.http.Status._
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import testutils.WireMockHelper
 import testutils.WireMockStubRequestBodies._
 
@@ -50,7 +51,8 @@ class SecureCommsAlertConnectorIT extends IntegrationBaseSpec with WireMockHelpe
 
         val expectedResult = SecureCommsResponseModel(dateTimeToUser, validEDODString)
 
-        val result: Either[ErrorModel, SecureCommsResponseModel] = await(connector.getSecureCommsMessage(service, regNum, communicationId))
+        val result: Either[ErrorModel, SecureCommsResponseModel] =
+          await(connector.getSecureCommsMessage(service, regNum, communicationId))
         result shouldBe Right(expectedResult)
       }
     }
@@ -69,7 +71,8 @@ class SecureCommsAlertConnectorIT extends IntegrationBaseSpec with WireMockHelpe
 
         val expectedResult = Left(GenericParsingError)
 
-        val result: Either[ErrorModel, SecureCommsResponseModel] = await(connector.getSecureCommsMessage(service, regNum, communicationId))
+        val result: Either[ErrorModel, SecureCommsResponseModel] =
+          await(connector.getSecureCommsMessage(service, regNum, communicationId))
         result shouldBe expectedResult
       }
 
@@ -85,7 +88,8 @@ class SecureCommsAlertConnectorIT extends IntegrationBaseSpec with WireMockHelpe
 
         val expectedResult = Left(BadRequest)
 
-        val result: Either[ErrorModel, SecureCommsResponseModel] = await(connector.getSecureCommsMessage(service, regNum, communicationId))
+        val result: Either[ErrorModel, SecureCommsResponseModel] =
+          await(connector.getSecureCommsMessage(service, regNum, communicationId))
         result shouldBe expectedResult
       }
 
@@ -101,7 +105,8 @@ class SecureCommsAlertConnectorIT extends IntegrationBaseSpec with WireMockHelpe
 
         val expectedResult = Left(NotFoundNoMatch)
 
-        val result: Either[ErrorModel, SecureCommsResponseModel] = await(connector.getSecureCommsMessage(service, regNum, communicationId))
+        val result: Either[ErrorModel, SecureCommsResponseModel] =
+          await(connector.getSecureCommsMessage(service, regNum, communicationId))
         result shouldBe expectedResult
       }
 
@@ -117,7 +122,8 @@ class SecureCommsAlertConnectorIT extends IntegrationBaseSpec with WireMockHelpe
 
         val expectedResult = Left(ErrorModel(s"$REQUEST_TIMEOUT", "AN UNKNOWN ERROR HAS OCCURRED"))
 
-        val result: Either[ErrorModel, SecureCommsResponseModel] = await(connector.getSecureCommsMessage(service, regNum, communicationId))
+        val result: Either[ErrorModel, SecureCommsResponseModel] =
+          await(connector.getSecureCommsMessage(service, regNum, communicationId))
         result shouldBe expectedResult
       }
     }

--- a/it/connectors/SecureCommsServiceConnectorIT.scala
+++ b/it/connectors/SecureCommsServiceConnectorIT.scala
@@ -21,6 +21,7 @@ import models._
 import models.secureCommsServiceModels._
 import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import testutils.WireMockHelper
 
 class SecureCommsServiceConnectorIT extends IntegrationBaseSpec with WireMockHelper {

--- a/it/controllers/BankAccountControllerISpec.scala
+++ b/it/controllers/BankAccountControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class BankAccountControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/BusinessNameControllerISpec.scala
+++ b/it/controllers/BusinessNameControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class BusinessNameControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/ContactNumbersControllerISpec.scala
+++ b/it/controllers/ContactNumbersControllerISpec.scala
@@ -20,6 +20,7 @@ import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.http.Status.NO_CONTENT
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class ContactNumbersControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/DeregistrationControllerISpec.scala
+++ b/it/controllers/DeregistrationControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class DeregistrationControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/EmailControllerISpec.scala
+++ b/it/controllers/EmailControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class EmailControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/OptOutControllerISpec.scala
+++ b/it/controllers/OptOutControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class OptOutControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/PPOBControllerISpec.scala
+++ b/it/controllers/PPOBControllerISpec.scala
@@ -20,6 +20,7 @@ import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.http.Status.NO_CONTENT
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class PPOBControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/StaggerControllerISpec.scala
+++ b/it/controllers/StaggerControllerISpec.scala
@@ -20,6 +20,7 @@ import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.http.Status.NO_CONTENT
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class StaggerControllerISpec extends IntegrationBaseSpec {
 

--- a/it/controllers/WebAddressControllerISpec.scala
+++ b/it/controllers/WebAddressControllerISpec.scala
@@ -20,6 +20,7 @@ import play.api.http.Status.NO_CONTENT
 import common.ApiConstants._
 import helpers.IntegrationBaseSpec
 import play.api.libs.ws.WSRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 class WebAddressControllerISpec extends IntegrationBaseSpec {
 

--- a/it/helpers/IntegrationBaseSpec.scala
+++ b/it/helpers/IntegrationBaseSpec.scala
@@ -19,16 +19,17 @@ package helpers
 import config.AppConfig
 import org.scalatest.BeforeAndAfterAll
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.{Application, Environment, Mode}
 import testutils.WireMockHelper
 import uk.gov.hmrc.http.HttpClient
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
 
-trait IntegrationBaseSpec extends UnitSpec with WireMockHelper with GuiceOneServerPerSuite
+trait IntegrationBaseSpec extends AnyWordSpecLike with Matchers with WireMockHelper with GuiceOneServerPerSuite
   with BeforeAndAfterAll {
 
   val mockHost: String = WireMockHelper.host

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,15 +16,13 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy",
   url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
-resolvers += Resolver.url("hmrc-sbt-plugin-releases",
-  url("https://artefacts.tax.service.gov.uk/artifactory/hmrc-sbt-plugin-releases-local"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+sbt 'run -Dplay.http.router=testOnly.Routes -Dlogger.resource=logback-test.xml'

--- a/test/base/BaseSpec.scala
+++ b/test/base/BaseSpec.scala
@@ -17,25 +17,29 @@
 package base
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import modules.SchedulerModule
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.i18n.MessagesApi
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test.FakeRequest
-import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
 
-trait BaseSpec extends UnitSpec with GuiceOneAppPerSuite {
+trait BaseSpec extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite {
   implicit val actorSystem: ActorSystem = ActorSystem("TestActorSystem")
-  implicit val mat: ActorMaterializer = ActorMaterializer()
 
-  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
-  implicit val cc: ControllerComponents = stubControllerComponents()
-  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  override implicit lazy val app: Application = new GuiceApplicationBuilder().disable[SchedulerModule].build
+  lazy val injector: Injector = app.injector
+  implicit lazy val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+  implicit lazy val cc: ControllerComponents = injector.instanceOf[ControllerComponents]
+  implicit lazy val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
-  val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 }

--- a/test/controllers/BankAccountControllerSpec.scala
+++ b/test/controllers/BankAccountControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class BankAccountControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new BankAccountController(mockCommsEventService)
+  val controller = new BankAccountController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Repayment Bank Account Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Repayment Bank Account Change")
@@ -42,7 +43,7 @@ class BankAccountControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class BankAccountControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class BankAccountControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/BusinessNameControllerSpec.scala
+++ b/test/controllers/BusinessNameControllerSpec.scala
@@ -23,10 +23,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
+
+import scala.concurrent.Future
 
 class BusinessNameControllerSpec extends BaseSpec {
 
-  val controller = new BusinessNameController()
+  val controller = new BusinessNameController(cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Business Name Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Business Name Change")
@@ -36,7 +39,7 @@ class BusinessNameControllerSpec extends BaseSpec {
     "valid JSON is received" should {
 
       "return 204" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
         status(result) shouldBe NO_CONTENT
       }
     }
@@ -44,26 +47,26 @@ class BusinessNameControllerSpec extends BaseSpec {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/ContactNumbersControllerSpec.scala
+++ b/test/controllers/ContactNumbersControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class ContactNumbersControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new ContactNumbersController(mockCommsEventService)
+  val controller = new ContactNumbersController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Contact Numbers Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Contact Numbers Change")
@@ -42,7 +43,7 @@ class ContactNumbersControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class ContactNumbersControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class ContactNumbersControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/DeregistrationControllerSpec.scala
+++ b/test/controllers/DeregistrationControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class DeregistrationControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new DeregistrationController(mockCommsEventService)
+  val controller = new DeregistrationController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("De-registration")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("De-registration")
@@ -42,7 +43,7 @@ class DeregistrationControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class DeregistrationControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class DeregistrationControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class EmailControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new EmailController(mockCommsEventService)
+  val controller = new EmailController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Email Address Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Email Address Change")
@@ -42,7 +43,7 @@ class EmailControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class EmailControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class EmailControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/OptOutControllerSpec.scala
+++ b/test/controllers/OptOutControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class OptOutControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new OptOutController(mockCommsEventService)
+  val controller = new OptOutController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Opt Out Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Opt Out Change")
@@ -42,7 +43,7 @@ class OptOutControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class OptOutControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class OptOutControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/StaggerControllerSpec.scala
+++ b/test/controllers/StaggerControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class StaggerControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new StaggerController(mockCommsEventService)
+  val controller = new StaggerController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("VAT Stagger Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("VAT Stagger Change")
@@ -42,7 +43,7 @@ class StaggerControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class StaggerControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class StaggerControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/controllers/WebAddressControllerSpec.scala
+++ b/test/controllers/WebAddressControllerSpec.scala
@@ -24,12 +24,13 @@ import models.VatChangeEvent
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT}
 import play.api.libs.json.JsObject
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 
 import scala.concurrent.Future
 
 class WebAddressControllerSpec extends BaseSpec with MockCommsEventService {
 
-  val controller = new WebAddressController(mockCommsEventService)
+  val controller = new WebAddressController(mockCommsEventService, cc)
 
   val testRequestJson: JsObject        = vatChangeEventJson("Web Address Change")
   val testRequestModel: VatChangeEvent = vatChangeEventModel("Web Address Change")
@@ -42,7 +43,7 @@ class WebAddressControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 204" in {
           mockQueueRequest(testRequestModel)(Future.successful(true))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe NO_CONTENT
         }
@@ -52,7 +53,7 @@ class WebAddressControllerSpec extends BaseSpec with MockCommsEventService {
 
         "return 500" in {
           mockQueueRequest(testRequestModel)(Future.successful(false))
-          val result: Result = controller.handleEvent(request.withJsonBody(testRequestJson))
+          val result: Future[Result] = controller.handleEvent(request.withJsonBody(testRequestJson))
 
           status(result) shouldBe INTERNAL_SERVER_ERROR
         }
@@ -62,26 +63,26 @@ class WebAddressControllerSpec extends BaseSpec with MockCommsEventService {
     "invalid JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
-        jsonBodyOf(result) shouldBe invalidJsonResponse
+        val result: Future[Result] = controller.handleEvent(request.withJsonBody(invalidJsonRequest))
+        contentAsJson(result) shouldBe invalidJsonResponse
       }
     }
 
     "something other than JSON is received" should {
 
       "return 400" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
         status(result) shouldBe BAD_REQUEST
       }
 
       "return JSON describing the error" in {
-        val result: Result = controller.handleEvent(request.withBody(invalidRequestBody))
-        jsonBodyOf(result) shouldBe invalidFormatResponse
+        val result: Future[Result] = controller.handleEvent(request.withBody(invalidRequestBody))
+        contentAsJson(result) shouldBe invalidFormatResponse
       }
     }
   }

--- a/test/models/secureMessageAlertModels/StaggerDetailsModelSpec.scala
+++ b/test/models/secureMessageAlertModels/StaggerDetailsModelSpec.scala
@@ -17,9 +17,10 @@
 package models.secureMessageAlertModels
 
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.play.test.UnitSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-class StaggerDetailsModelSpec extends UnitSpec {
+class StaggerDetailsModelSpec extends AnyWordSpecLike with Matchers {
 
   val expectedModelForConfirmation: StaggerDetailsModel = StaggerDetailsModel(
     "stagger",

--- a/test/repositories/CommsEventQueueRepositorySpec.scala
+++ b/test/repositories/CommsEventQueueRepositorySpec.scala
@@ -20,14 +20,15 @@ import common.ApiConstants.vatChangeEventModel
 import models.VatChangeEvent
 import org.joda.time.{DateTime, Duration}
 import org.scalatest.BeforeAndAfterEach
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.api.ReadPreference
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem._
 
 class CommsEventQueueRepositorySpec extends MongoSpec[VatChangeEvent, CommsEventQueueRepository] with BeforeAndAfterEach {
+
   val anInstant: DateTime = DateTimeUtils.now
-  override implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
 
   "CommsEventQueue Repository" should {
 
@@ -63,7 +64,7 @@ class CommsEventQueueRepositorySpec extends MongoSpec[VatChangeEvent, CommsEvent
       requests should have(size(2))
 
 
-      requests(0) should have(
+      requests.head should have(
         'item (payloadDetails),
         'status (ToDo),
         'receivedAt (anInstant),

--- a/test/repositories/EmailMessageQueueRepositorySpec.scala
+++ b/test/repositories/EmailMessageQueueRepositorySpec.scala
@@ -19,16 +19,17 @@ package repositories
 import models.SecureCommsMessageModel
 import org.joda.time.DateTime
 import org.scalatest.BeforeAndAfterEach
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.api.ReadPreference
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem._
 import utils.SecureCommsMessageTestData.Responses.expectedResponseEverything
 
+class EmailMessageQueueRepositorySpec extends MongoSpec[SecureCommsMessageModel, EmailMessageQueueRepository] with
+  BeforeAndAfterEach {
 
-class EmailMessageQueueRepositorySpec extends MongoSpec[SecureCommsMessageModel, EmailMessageQueueRepository] with BeforeAndAfterEach {
   val anInstant: DateTime = DateTimeUtils.now
-  override implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
 
   "EmailMessageQueue Repository" should {
 
@@ -54,7 +55,7 @@ class EmailMessageQueueRepositorySpec extends MongoSpec[SecureCommsMessageModel,
       val requests = await(repo.findAll(ReadPreference.primaryPreferred))
       requests should have(size(2))
 
-      requests(0) should have(
+      requests.head should have(
         'item (expectedResponseEverything),
         'status (ToDo),
         'receivedAt (anInstant),

--- a/test/repositories/MongoSpec.scala
+++ b/test/repositories/MongoSpec.scala
@@ -16,34 +16,32 @@
 
 package repositories
 
-import akka.stream.Materializer
 import mocks.MockAppConfig
 import modules.SchedulerModule
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
 import play.api.inject.Injector
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.workitem.WorkItemRepository
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag
 
-abstract class MongoSpec[A, T <: WorkItemRepository[A, _]](implicit classTag: ClassTag[T]) extends UnitSpec with BeforeAndAfterEach with BeforeAndAfterAll {
+abstract class MongoSpec[A, T <: WorkItemRepository[A, _]](implicit classTag: ClassTag[T]) extends
+  AnyWordSpecLike with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit lazy val app: Application = new GuiceApplicationBuilder().disable[SchedulerModule].build
   val injector: Injector = app.injector
   implicit val mockAppConfig: MockAppConfig = new MockAppConfig(app.configuration)
 
-  implicit val materializer: Materializer = app.materializer
-
   implicit val hc: HeaderCarrier = HeaderCarrier()
-  implicit val ec: ExecutionContext
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
 
   val repo: T = app.injector.instanceOf[T]
-
 
   def dropDatabase(): Unit = Await.result(repo.removeAll(), Duration.Inf)
 
@@ -56,5 +54,4 @@ abstract class MongoSpec[A, T <: WorkItemRepository[A, _]](implicit classTag: Cl
     app.stop()
     super.afterAll()
   }
-
 }

--- a/test/repositories/SecureMessageQueueRepositorySpec.scala
+++ b/test/repositories/SecureMessageQueueRepositorySpec.scala
@@ -18,15 +18,15 @@ package repositories
 
 import models.SecureCommsMessageModel
 import org.joda.time.DateTime
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.api.ReadPreference
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.time.DateTimeUtils
 import uk.gov.hmrc.workitem._
 import utils.SecureCommsMessageTestData.Responses.expectedResponseEverything
 
-
 class SecureMessageQueueRepositorySpec extends MongoSpec[SecureCommsMessageModel, SecureMessageQueueRepository] {
-  override implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+
   val anInstant: DateTime = DateTimeUtils.now
 
   "SecureMessageQueue Repository" should {
@@ -54,7 +54,7 @@ class SecureMessageQueueRepositorySpec extends MongoSpec[SecureCommsMessageModel
       requests should have(size(2))
 
 
-      requests(0) should have(
+      requests.head should have(
         'item (expectedResponseEverything),
         'status (ToDo),
         'receivedAt (anInstant),

--- a/test/services/CommsEventServiceSpec.scala
+++ b/test/services/CommsEventServiceSpec.scala
@@ -27,6 +27,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.bson.BSONObjectID
 import repositories.CommsEventQueueRepository
 import uk.gov.hmrc.http.GatewayTimeoutException

--- a/test/services/EmailMessageServiceSpec.scala
+++ b/test/services/EmailMessageServiceSpec.scala
@@ -28,6 +28,7 @@ import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status.ACCEPTED
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.bson.BSONObjectID
 import repositories.EmailMessageQueueRepository
 import uk.gov.hmrc.workitem.{InProgress, ProcessingStatus, WorkItem}

--- a/test/services/EmailServiceSpec.scala
+++ b/test/services/EmailServiceSpec.scala
@@ -31,6 +31,7 @@ import models.secureMessageAlertModels.messageTypes.{EmailAddressChangeModel, Me
 import models.secureMessageAlertModels.{CustomerModel, PreferencesModel, TransactorModel}
 import org.scalamock.scalatest.MockFactory
 import play.api.http.Status.ACCEPTED
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -49,7 +50,7 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
     PreferencesModel(EMAIL, PAPER, ENGLISH, TEXT)
   )
 
-  val emailRequestModel = EmailRequestModel(
+  val emailRequestModel: EmailRequestModel = EmailRequestModel(
     Seq(messageModel.getTransactorDetails.transactorEmail),
     "newMessageAlert_VRT12B",
     Map(
@@ -59,7 +60,7 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
     )
   )
 
-  val errorModel = ErrorModel("ERROR_CREATING_REQUEST", "Oh no")
+  val errorModel: ErrorModel = ErrorModel("ERROR_CREATING_REQUEST", "Oh no")
 
   "sendEmailRequest" should {
 

--- a/test/services/SecureCommsAlertServiceSpec.scala
+++ b/test/services/SecureCommsAlertServiceSpec.scala
@@ -21,10 +21,11 @@ import connectors.SecureCommsAlertConnector
 import models.responseModels.SecureCommsResponseModel
 import models.{ErrorModel, GenericParsingError, JsonParsingError}
 import org.scalamock.scalatest.MockFactory
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import utils.SecureCommsMessageBodyStrings
 import utils.SecureCommsMessageTestData.Responses.expectedResponseDeRegistration
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class SecureCommsAlertServiceSpec extends BaseSpec with MockFactory {
 
@@ -42,10 +43,10 @@ class SecureCommsAlertServiceSpec extends BaseSpec with MockFactory {
         (mockConnector.getSecureCommsMessage(_: String, _: String, _: String)(_: ExecutionContext))
             .expects(serviceName, regNum, communicationsId, *)
             .returns(
-              Right(SecureCommsResponseModel(
+              Future.successful(Right(SecureCommsResponseModel(
                 dateToUse,
                 SecureCommsMessageBodyStrings.validEDODString
-              ))
+              )))
             )
 
         val result = await(service.getSecureCommsMessage(serviceName, regNum, communicationsId))
@@ -57,10 +58,10 @@ class SecureCommsAlertServiceSpec extends BaseSpec with MockFactory {
         (mockConnector.getSecureCommsMessage(_: String, _: String, _: String)(_: ExecutionContext))
           .expects(serviceName, regNum, communicationsId, *)
           .returns(
-            Right(SecureCommsResponseModel(
+            Future.successful(Right(SecureCommsResponseModel(
               dateToUse,
               SecureCommsMessageBodyStrings.invalidEDODString
-            ))
+            )))
           )
 
         val result = await(service.getSecureCommsMessage(serviceName, regNum, communicationsId))
@@ -70,10 +71,10 @@ class SecureCommsAlertServiceSpec extends BaseSpec with MockFactory {
         (mockConnector.getSecureCommsMessage(_: String, _: String, _: String)(_: ExecutionContext))
           .expects(serviceName, regNum, communicationsId, *)
           .returns(
-            Right(SecureCommsResponseModel(
+            Future.successful(Right(SecureCommsResponseModel(
               dateToUse,
               SecureCommsMessageBodyStrings.invalidJsonParseString
-            ))
+            )))
           )
 
         val result = await(service.getSecureCommsMessage(serviceName, regNum, communicationsId))
@@ -85,7 +86,7 @@ class SecureCommsAlertServiceSpec extends BaseSpec with MockFactory {
         (mockConnector.getSecureCommsMessage(_: String, _: String, _: String)(_: ExecutionContext))
           .expects(serviceName, regNum, communicationsId, *)
           .returns(
-            Left(modelToReturn)
+            Future.successful(Left(modelToReturn))
           )
 
         val result = await(service.getSecureCommsMessage(serviceName, regNum, communicationsId))

--- a/test/services/SecureCommsServiceSpec.scala
+++ b/test/services/SecureCommsServiceSpec.scala
@@ -17,30 +17,24 @@
 package services
 
 import java.time.format.DateTimeParseException
-
 import base.BaseSpec
 import common.Constants.MessageKeys._
 import connectors.SecureCommsServiceConnector
 import mocks.MockAppConfig
 import models._
 import models.secureCommsServiceModels._
-import modules.SchedulerModule
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
-import play.api.Application
-import play.api.inject.Injector
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import utils.SecureCommsMessageTestData.SendSecureMessageModels._
 import utils.SecureCommsServiceInjections
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAfterAll {
 
   val mockConnector: SecureCommsServiceConnector = mock[SecureCommsServiceConnector]
 
-  implicit override lazy val app: Application = new GuiceApplicationBuilder().disable[SchedulerModule].build
-  lazy val injector: Injector = app.injector
   implicit val mockAppConfig: MockAppConfig = new MockAppConfig(app.configuration)
 
   val sCSViews: SecureCommsServiceInjections = new SecureCommsServiceInjections(injector)
@@ -288,7 +282,7 @@ class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAft
       "an exception is encountered" in {
         (mockConnector.sendMessage(_: SecureCommsServiceRequestModel)(_: ExecutionContext))
           .expects(*, *)
-          .returns(Left(BadRequest))
+          .returns(Future.successful(Left(BadRequest)))
 
         val result = await(service.sendSecureCommsMessage(emailValidRejectedClientRequest))
         result shouldBe Left(BadRequest)
@@ -492,6 +486,6 @@ class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAft
   private def setupSuccessResponse = {
     (mockConnector.sendMessage(_: SecureCommsServiceRequestModel)(_: ExecutionContext))
       .expects(*, *)
-      .returns(Right(true))
+      .returns(Future.successful(Right(true)))
   }
 }

--- a/test/services/SecureMessageServiceSpec.scala
+++ b/test/services/SecureMessageServiceSpec.scala
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.bson.BSONObjectID
 import repositories.SecureMessageQueueRepository
 import uk.gov.hmrc.workitem.{InProgress, ProcessingStatus, WorkItem}

--- a/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
+++ b/test/testOnly/controllers/CommsEventQueueControllerSpec.scala
@@ -20,6 +20,7 @@ import base.BaseSpec
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
 import repositories.CommsEventQueueRepository
 import services.CommsEventQueuePollingService
 
@@ -29,7 +30,7 @@ class CommsEventQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: CommsEventQueueRepository = mock[CommsEventQueueRepository]
   val scheduler: CommsEventQueuePollingService = mock[CommsEventQueuePollingService]
-  val controller = new CommsEventQueueController(repository, scheduler)
+  val controller = new CommsEventQueueController(repository, scheduler, cc)
   val recordCount = 99
 
   "The count action" should {
@@ -38,7 +39,7 @@ class CommsEventQueueControllerSpec extends BaseSpec with MockitoSugar {
       when(repository.count(ec)) thenReturn Future.successful(recordCount)
       lazy val result: Future[Result] = controller.count(request)
 
-      await(bodyOf(result)) shouldBe recordCount.toString
+      contentAsString(result) shouldBe recordCount.toString
     }
   }
 }

--- a/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/EmailMessageQueueControllerSpec.scala
@@ -20,6 +20,7 @@ import base.BaseSpec
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
 import repositories.EmailMessageQueueRepository
 import services.EmailMessageQueuePollingService
 
@@ -29,7 +30,7 @@ class EmailMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: EmailMessageQueueRepository = mock[EmailMessageQueueRepository]
   val scheduler: EmailMessageQueuePollingService = mock[EmailMessageQueuePollingService]
-  val controller = new EmailMessageQueueController(repository, scheduler)
+  val controller = new EmailMessageQueueController(repository, scheduler, cc)
   val recordCount = 99
 
   "The count action" should {
@@ -38,7 +39,7 @@ class EmailMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
       when(repository.count(ec)) thenReturn Future.successful(recordCount)
       lazy val result: Future[Result] = controller.count(request)
 
-      await(bodyOf(result)) shouldBe recordCount.toString
+      contentAsString(result) shouldBe recordCount.toString
     }
   }
 }

--- a/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
+++ b/test/testOnly/controllers/SecureMessageQueueControllerSpec.scala
@@ -20,6 +20,7 @@ import base.BaseSpec
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
 import repositories.SecureMessageQueueRepository
 import services.SecureMessageQueuePollingService
 
@@ -29,7 +30,7 @@ class SecureMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
 
   val repository: SecureMessageQueueRepository = mock[SecureMessageQueueRepository]
   val scheduler: SecureMessageQueuePollingService = mock[SecureMessageQueuePollingService]
-  val controller = new SecureMessageQueueController(repository, scheduler)
+  val controller = new SecureMessageQueueController(repository, scheduler, cc)
   val recordCount = 99
 
   "The count action" should {
@@ -38,7 +39,7 @@ class SecureMessageQueueControllerSpec extends BaseSpec with MockitoSugar {
       when(repository.count(ec)) thenReturn Future.successful(recordCount)
       lazy val result: Future[Result] = controller.count(request)
 
-      await(bodyOf(result)) shouldBe recordCount.toString
+      contentAsString(result) shouldBe recordCount.toString
     }
   }
 }

--- a/test/utils/ExclusiveScheduledJobSpec.scala
+++ b/test/utils/ExclusiveScheduledJobSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class ExclusiveScheduledJobSpec extends AnyWordSpec with Matchers with ScalaFutures {
+
+
+  override implicit def patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  class SimpleJob extends ExclusiveScheduledJob {
+
+    val start = new CountDownLatch(1)
+
+    def continueExecution(): Unit = start.countDown()
+
+    val executionCount = new AtomicInteger(0)
+
+    def executions: Int = executionCount.get()
+
+    override def executeInMutex(implicit ec: ExecutionContext): Future[Result] =
+      Future {
+        start.await(1, TimeUnit.MINUTES)
+        Result(executionCount.incrementAndGet().toString)
+      }
+
+    override def name: String = "simpleJob"
+
+    override def initialDelay: FiniteDuration = FiniteDuration(1, TimeUnit.MINUTES)
+
+    override def interval: FiniteDuration = FiniteDuration(1, TimeUnit.MINUTES)
+  }
+
+  "ExclusiveScheduledJob" should {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    "let the jobs run in sequence" in {
+      val job = new SimpleJob
+      job.continueExecution()
+      job.execute.futureValue.message shouldBe "1"
+      job.execute.futureValue.message shouldBe "2"
+    }
+
+    "not allow jobs to run in parallel" in {
+      val job = new SimpleJob
+
+      val pausedExecution = job.execute
+      pausedExecution.isCompleted shouldBe false
+      job.execute.futureValue.message shouldBe "Skipping execution: job running"
+
+      job.continueExecution()
+      pausedExecution.futureValue.message shouldBe "1"
+    }
+
+    "should tolerate exceptions in execution" in {
+      val job = new SimpleJob() {
+        override def executeInMutex(implicit ec: ExecutionContext): Future[Result] = throw new RuntimeException
+      }
+
+      Try(job.execute.futureValue)
+
+      job.isRunning.futureValue shouldBe false
+    }
+  }
+}

--- a/test/views/ViewBaseSpec.scala
+++ b/test/views/ViewBaseSpec.scala
@@ -17,25 +17,29 @@
 package views
 
 import mocks.MockAppConfig
+import modules.SchedulerModule
 import org.jsoup.nodes.{Document, Element}
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Configuration
+import play.api.{Application, Configuration}
 import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
 import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.collection.JavaConverters._
 
-trait ViewBaseSpec extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterAll {
+trait ViewBaseSpec extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite with BeforeAndAfterAll {
 
   lazy implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  override implicit lazy val app: Application = new GuiceApplicationBuilder().disable[SchedulerModule].build
   lazy val injector: Injector = app.injector
-  implicit val messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   implicit val messages: Messages = MessagesImpl(Lang("en-GB"), messagesApi)
-  implicit val mockAppConfig: MockAppConfig = new MockAppConfig(injector.instanceOf[Configuration])
+  implicit val mockAppConfig: MockAppConfig = new MockAppConfig(app.injector.instanceOf[Configuration])
 
   override def afterAll(): Unit = {
     app.stop()

--- a/test/views/templates/TemplateBaseSpec.scala
+++ b/test/views/templates/TemplateBaseSpec.scala
@@ -17,15 +17,16 @@
 package views.templates
 
 import org.jsoup.Jsoup
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
 import play.api.inject.Injector
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.twirl.api.Html
-import uk.gov.hmrc.play.test.UnitSpec
 
-class TemplateBaseSpec extends UnitSpec with GuiceOneAppPerSuite {
+class TemplateBaseSpec extends AnyWordSpecLike with Matchers with GuiceOneAppPerSuite {
 
   lazy implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
   lazy val injector: Injector = app.injector


### PR DESCRIPTION
I had to do some bits of refactoring in the tests due to explosions which seemed to be caused by a mix of Controller inheritance and the SchedulerModule which needed disabling where appropriate.

I also had to instantiate an anonymous object to extend from `LoggerUtil` to use our `logger` in the QueueRepository files due to there being another `logger` inside `ReactiveRepository`.