### PR TITLE
[BTAT-9928]-Increase Test Coverage for mtd vat comms

### DIFF
--- a/app/controllers/DeregistrationController.scala
+++ b/app/controllers/DeregistrationController.scala
@@ -25,7 +25,7 @@ import services.CommsEventService
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Right
 
-class DeregistrationController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
+class  DeregistrationController @Inject()(repoAccess: CommsEventService, cc: ControllerComponents)
                                         (implicit ec: ExecutionContext) extends MicroserviceBaseController(cc) {
 
   def handleEvent: Action[AnyContent] = Action.async { implicit request =>

--- a/app/services/EmailMessageService.scala
+++ b/app/services/EmailMessageService.scala
@@ -50,7 +50,7 @@ class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQue
 
   def processWorkItem(acc: Seq[SecureCommsMessageModel],
                       workItem: WorkItem[SecureCommsMessageModel]): Future[Seq[SecureCommsMessageModel]] = {
-    try {
+
       SecureCommsMessageParser.parseModel(workItem.item) match {
         case Right(message) => emailService.sendEmailRequest(message).flatMap {
           case Right(_) =>
@@ -70,11 +70,6 @@ class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQue
           metrics.emailMessageParsingError()
           handleNonRecoverableError(acc, workItem, "ParsingError")
       }
-    } catch {
-      case e: Throwable =>
-        metrics.emailMessageUnexpectedError()
-        handleNonRecoverableError(acc, workItem, "UnexpectedError", Some(e))
-    }
   }.recoverWith {
     case e =>
       metrics.emailMessageUnexpectedError()

--- a/app/services/EmailMessageService.scala
+++ b/app/services/EmailMessageService.scala
@@ -30,7 +30,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQueueRepository,
                                     emailService: EmailService,
                                     metrics: QueueMetrics)(
-                                    implicit ec: ExecutionContext) extends LoggerUtil {
+                                     implicit ec: ExecutionContext) extends LoggerUtil {
 
   def queueRequest(item: SecureCommsMessageModel): Future[Boolean] = {
     metrics.emailMessageEnqueued()
@@ -50,7 +50,7 @@ class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQue
 
   def processWorkItem(acc: Seq[SecureCommsMessageModel],
                       workItem: WorkItem[SecureCommsMessageModel]): Future[Seq[SecureCommsMessageModel]] = {
-
+    try {
       SecureCommsMessageParser.parseModel(workItem.item) match {
         case Right(message) => emailService.sendEmailRequest(message).flatMap {
           case Right(_) =>
@@ -70,6 +70,11 @@ class EmailMessageService @Inject()(emailMessageQueueRepository: EmailMessageQue
           metrics.emailMessageParsingError()
           handleNonRecoverableError(acc, workItem, "ParsingError")
       }
+    } catch {
+      case e: Throwable =>
+        metrics.emailMessageUnexpectedError()
+        handleNonRecoverableError(acc, workItem, "UnexpectedError", Some(e))
+    }
   }.recoverWith {
     case e =>
       metrics.emailMessageUnexpectedError()

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -17,8 +17,6 @@
 package services
 
 import java.util.NoSuchElementException
-
-import ch.qos.logback.classic.pattern.ClassOfCallerConverter
 import common.Constants.TemplateIdReadableNames._
 import connectors.EmailConnector
 import javax.inject.Inject

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -16,6 +16,9 @@
 
 package services
 
+import java.util.NoSuchElementException
+
+import ch.qos.logback.classic.pattern.ClassOfCallerConverter
 import common.Constants.TemplateIdReadableNames._
 import connectors.EmailConnector
 import javax.inject.Inject
@@ -28,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class EmailService @Inject()(emailRendererConnector: EmailConnector) {
 
+  @throws(classOf[NoSuchElementException])
   def sendEmailRequest(message: MessageModel)
                       (implicit ec: ExecutionContext): Future[Either[ErrorModel, EmailRendererResponseModel]] = {
     val mappedTemplateId = mapTemplateId(message.getTemplateId)

--- a/test/services/CommsEventServiceSpec.scala
+++ b/test/services/CommsEventServiceSpec.scala
@@ -218,16 +218,6 @@ class CommsEventServiceSpec extends BaseSpec with MockitoSugar {
         verify(metrics, times(1)).commsEventUnexpectedError()
       }
     }
-    "the secure message request is unsuccessfully sent but its a recoverable error" should {
-
-      "mark the item as failed" in new TestSetup {
-        secureCommsAlertMock(Left(ErrorModel("Some general error", "Not of the non recoverable types")))
-        markItemAsFailedMock
-        await(commsEventService.processWorkItem(Seq.empty, exampleWorkItem))
-
-        verify(queue, never()).complete(any())
-      }
-    }
   }
 
   trait TestSetup {

--- a/test/services/CommsEventServiceSpec.scala
+++ b/test/services/CommsEventServiceSpec.scala
@@ -240,10 +240,6 @@ class CommsEventServiceSpec extends BaseSpec with MockitoSugar {
       when(secureCommsAlertService.getSecureCommsMessage(any(), any(), any())(any()))
         .thenReturn(Future.failed(new UnknownHostException("some error")))
 
-    def secureCommsAlertUnexpectedExceptionMock(): OngoingStubbing[Future[Either[ErrorModel, SecureCommsMessageModel]]] =
-      when(secureCommsAlertService.getSecureCommsMessage(any(), any(), any())(any()))
-        .thenReturn(Future.failed(UnexpectedException(Some("some error"))))
-
     def gatewayTimeoutMock(): OngoingStubbing[Future[Either[ErrorModel, SecureCommsMessageModel]]] =
       when(secureCommsAlertService.getSecureCommsMessage(any(), any(), any())(any()))
         .thenReturn(Future.failed(new GatewayTimeoutException("some error")))

--- a/test/services/CommsEventServiceSpec.scala
+++ b/test/services/CommsEventServiceSpec.scala
@@ -27,7 +27,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.UnexpectedException
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import reactivemongo.bson.BSONObjectID
 import repositories.CommsEventQueueRepository

--- a/test/services/EmailServiceSpec.scala
+++ b/test/services/EmailServiceSpec.scala
@@ -16,6 +16,8 @@
 
 package services
 
+import java.util.NoSuchElementException
+
 import base.BaseSpec
 import common.Constants.ChannelPreferences.PAPER
 import common.Constants.EmailStatus.VERIFIED
@@ -27,7 +29,7 @@ import connectors.EmailConnector
 import models.ErrorModel
 import models.emailRendererModels.EmailRequestModel
 import models.responseModels.EmailRendererResponseModel
-import models.secureMessageAlertModels.messageTypes.{EmailAddressChangeModel, MessageModel}
+import models.secureMessageAlertModels.messageTypes.{DeRegistrationModel, EmailAddressChangeModel, MessageModel}
 import models.secureMessageAlertModels.{CustomerModel, PreferencesModel, TransactorModel}
 import org.scalamock.scalatest.MockFactory
 import play.api.http.Status.ACCEPTED
@@ -51,13 +53,24 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
   )
 
   val messageModelError: MessageModel = new MessageModel(
-    "VRT12A_SM9A",
+    "BLAH BLAH",
     "123123123",
     "AID_32I1",
     "testBusinessName",
     TransactorModel("test@email.com", "test"),
     CustomerModel("cus@tom.e.r", VERIFIED),
     PreferencesModel(EMAIL, PAPER, ENGLISH, TEXT)
+  )
+
+  val deregistrationMessageModelError: MessageModel = new DeRegistrationModel(
+    "VRT12A_SM9A",
+    "123123123",
+    "AID_32I1",
+    "testBusinessName",
+    TransactorModel("test@email.com", "test"),
+    CustomerModel("cus@tom.e.r", VERIFIED),
+    PreferencesModel(EMAIL, PAPER, ENGLISH, TEXT),
+    effectiveDateOfDeregistration = "2021-02-01"
   )
 
   val emailRequestModel: EmailRequestModel = EmailRequestModel(
@@ -84,10 +97,12 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
       val result: Either[ErrorModel, EmailRendererResponseModel] = await(service.sendEmailRequest(messageModel))
       result shouldBe Right(EmailRendererResponseModel(ACCEPTED))
     }
-    "return a Left when an incorrect template id has been passed" in {
-
-      val result: Either[ErrorModel, EmailRendererResponseModel] = await(service.sendEmailRequest(messageModelError))
+    "return a Left(error) when the combination of the type of the change and the template id are invalid" in {
+      val result: Either[ErrorModel, EmailRendererResponseModel] = await(service.sendEmailRequest(deregistrationMessageModelError))
       result shouldBe Left(errorModelLeft)
+    }
+    "return a NoSuchElementException when an incorrect template id has been passed" in {
+      intercept[NoSuchElementException](await(service.sendEmailRequest(messageModelError)))
     }
 
     "return an ErrorModel when unsuccessful" in {

--- a/test/services/EmailServiceSpec.scala
+++ b/test/services/EmailServiceSpec.scala
@@ -50,6 +50,16 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
     PreferencesModel(EMAIL, PAPER, ENGLISH, TEXT)
   )
 
+  val messageModelError: MessageModel = new MessageModel(
+    "VRT12A_SM9A",
+    "123123123",
+    "AID_32I1",
+    "testBusinessName",
+    TransactorModel("test@email.com", "test"),
+    CustomerModel("cus@tom.e.r", VERIFIED),
+    PreferencesModel(EMAIL, PAPER, ENGLISH, TEXT)
+  )
+
   val emailRequestModel: EmailRequestModel = EmailRequestModel(
     Seq(messageModel.getTransactorDetails.transactorEmail),
     "newMessageAlert_VRT12B",
@@ -61,6 +71,7 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
   )
 
   val errorModel: ErrorModel = ErrorModel("ERROR_CREATING_REQUEST", "Oh no")
+  val errorModelLeft: ErrorModel = ErrorModel("ERROR_CREATING_REQUEST", "Template ID 'newMessageAlert_VRT1214A' is not supported.")
 
   "sendEmailRequest" should {
 
@@ -72,6 +83,11 @@ class EmailServiceSpec extends BaseSpec with MockFactory {
 
       val result: Either[ErrorModel, EmailRendererResponseModel] = await(service.sendEmailRequest(messageModel))
       result shouldBe Right(EmailRendererResponseModel(ACCEPTED))
+    }
+    "return a Left when an incorrect template id has been passed" in {
+
+      val result: Either[ErrorModel, EmailRendererResponseModel] = await(service.sendEmailRequest(messageModelError))
+      result shouldBe Left(errorModelLeft)
     }
 
     "return an ErrorModel when unsuccessful" in {

--- a/test/services/SecureCommsServiceSpec.scala
+++ b/test/services/SecureCommsServiceSpec.scala
@@ -270,8 +270,8 @@ class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAft
         result shouldBe Right(true)
       }
       "return a specific parsing error" when {
-        "the model can't be parsed" in {
-          val result = await(service.sendSecureCommsMessage(messageModelDeRegistrationInvalidTemplateNoFields))
+        "the model can't be matched to a specific change type" in {
+          val result = await(service.sendSecureCommsMessage(messageModelNoFields))
           result shouldBe Left(SpecificParsingError)
         }
       }

--- a/test/services/SecureCommsServiceSpec.scala
+++ b/test/services/SecureCommsServiceSpec.scala
@@ -269,6 +269,12 @@ class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAft
         val result = await(service.sendSecureCommsMessage(contactNumbersValidApprovedTransactorRequest))
         result shouldBe Right(true)
       }
+      "return a specific parsing error" when {
+        "the model can't be parsed" in {
+          val result = await(service.sendSecureCommsMessage(messageModelDeRegistrationInvalidTemplateNoFields))
+          result shouldBe Left(SpecificParsingError)
+        }
+      }
     }
 
     "return an error when there is an invalid template id" when {
@@ -277,7 +283,6 @@ class SecureCommsServiceSpec extends BaseSpec with MockFactory with BeforeAndAft
         result shouldBe Left(GenericQueueNoRetryError)
       }
     }
-
     "return an error" when {
       "an exception is encountered" in {
         (mockConnector.sendMessage(_: SecureCommsServiceRequestModel)(_: ExecutionContext))

--- a/test/services/SecureMessageServiceSpec.scala
+++ b/test/services/SecureMessageServiceSpec.scala
@@ -116,7 +116,6 @@ class SecureMessageServiceSpec extends BaseSpec with MockitoSugar {
           "mark the item as failed" in new TestSetup {
             secureCommsMock(Left(ErrorModel("Some general error", "Not of the non recoverable types")))
             markItemAsFailedMock
-
             await(secureMessageService.processWorkItem(Seq.empty, exampleWorkItem))
 
             verify(queue, never()).complete(any())

--- a/test/utils/ExclusiveScheduledJobSpec.scala
+++ b/test/utils/ExclusiveScheduledJobSpec.scala
@@ -64,6 +64,7 @@ class ExclusiveScheduledJobSpec extends AnyWordSpec with Matchers with ScalaFutu
       job.continueExecution()
       job.execute.futureValue.message shouldBe "1"
       job.execute.futureValue.message shouldBe "2"
+      job.toString() shouldBe "simpleJob after 1 minute every 1 minute"
     }
 
     "not allow jobs to run in parallel" in {

--- a/test/utils/SecureCommsMessageTestData.scala
+++ b/test/utils/SecureCommsMessageTestData.scala
@@ -463,7 +463,7 @@ object SecureCommsMessageTestData {
       PreferencesModel(EMAIL, DIGITAL, ENGLISH, TEXT)
     )
 
-    val messageModelDeRegistrationInvalidTemplateNoFields = SecureCommsMessageModel(
+    val messageModelNoFields: SecureCommsMessageModel = SecureCommsMessageModel(
       "NO SUCH ID",
       "123456789",
       "092000003080",
@@ -737,7 +737,7 @@ object SecureCommsMessageTestData {
       PreferencesModel(EMAIL, DIGITAL, ENGLISH, TEXT)
     )
 
-    val staggerInvalidCodeRequest: SecureCommsMessageModel = staggerValidApprovedClientRequest.copy(
+    val staggerInvalidCodeRequest:  SecureCommsMessageModel = staggerValidApprovedClientRequest.copy(
       staggerDetails = Some(StaggerDetailsModel("InvalidStaggerCode", "", "", "", "", ""))
     )
 

--- a/test/utils/SecureCommsMessageTestData.scala
+++ b/test/utils/SecureCommsMessageTestData.scala
@@ -463,6 +463,24 @@ object SecureCommsMessageTestData {
       PreferencesModel(EMAIL, DIGITAL, ENGLISH, TEXT)
     )
 
+    val messageModelDeRegistrationInvalidTemplateNoFields = SecureCommsMessageModel(
+      "NO SUCH ID",
+      "123456789",
+      "092000003080",
+      "testBusinessName",
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      transactorModel,
+      CustomerModel("testCustomer@email.co.uk", VERIFIED),
+      PreferencesModel(EMAIL, DIGITAL, ENGLISH, TEXT)
+    )
+
     val deRegistrationValidApprovedTransactorRequest = SecureCommsMessageModel(
       "VRT23C_SM7C",
       "123456789",


### PR DESCRIPTION
The only files where I was unable to get the coverage up were the services files that use the retrieveWorkItems function which is from a hmrc package called work item. Speaking to Lewis he said there isn't any need to test as the code behind is not ours and goes beyond the scope of unit tests. 