### PR TITLE
Improved logging at the connector/http parser level

### DIFF
--- a/app/utils/LoggerUtil.scala
+++ b/app/utils/LoggerUtil.scala
@@ -16,17 +16,9 @@
 
 package utils
 
-import models.ErrorModel
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.LoggerLike
 
 trait LoggerUtil extends LoggerLike {
   override val logger: Logger = LoggerFactory.getLogger("application")
-  def logWarnEitherError[T](content: Either[ErrorModel, T]): Either[ErrorModel, T] = {
-    if(content.isLeft) {
-      val leftValue = content.left.get
-      logger.warn(s"${leftValue.code} => ${leftValue.body}")
-    }
-    content
-  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val appDependencies: Seq[ModuleID] = compile ++ test() ++ tmpMacWorkaround(
 val compile = Seq(
   "uk.gov.hmrc" %% "simple-reactivemongo"      % "8.0.0-play-28",
   "uk.gov.hmrc" %% "work-item-repo"            % "8.1.0-play-28",
-  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.14.0"
+  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.17.0"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy",
   url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 


### PR DESCRIPTION
I've removed the rubbish "x => y" logging error we were adding to each connector call, and instead put logger messages into the HTTP parsers. This gives us better quality logs as it will print out the response body from the actual service that sent us the error.