### PR TITLE
BTAT-11457 Upgraded HMRC mongo

### DIFF
--- a/app/repositories/EmailMessageQueueRepository.scala
+++ b/app/repositories/EmailMessageQueueRepository.scala
@@ -21,7 +21,7 @@ import models.SecureCommsMessageModel
 import org.bson.types.ObjectId
 import org.mongodb.scala.model.Filters.{and, equal}
 import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
-import uk.gov.hmrc.mongo.{MongoComponent, MongoUtils}
+import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.workitem.{WorkItem, WorkItemFields, WorkItemRepository}
 import uk.gov.hmrc.mongo.workitem.ProcessingStatus._
 
@@ -37,22 +37,17 @@ class EmailMessageQueueRepository @Inject()(appConfig: AppConfig, mongoComponent
     "EmailMessageQueue",
     mongoComponent,
     SecureCommsMessageModel.format,
-    WorkItemFields.default
+    WorkItemFields.default,
+    extraIndexes = Seq(IndexModel(
+      Indexes.ascending("receivedAt"),
+      IndexOptions().name("workItemExpiry").expireAfter(appConfig.queueItemExpirySeconds, TimeUnit.SECONDS)
+    )),
+    replaceIndexes = true
   ) {
 
   override lazy val inProgressRetryAfter: Duration = Duration.ofMillis(appConfig.retryIntervalMillis)
 
   override def now(): Instant = Instant.now()
-
-  override def ensureIndexes: Future[Seq[String]] =
-    MongoUtils.ensureIndexes(
-      collection,
-      Seq(IndexModel(
-        Indexes.ascending("receivedAt"),
-        IndexOptions().name("workItemExpiry").expireAfter(appConfig.queueItemExpirySeconds, TimeUnit.SECONDS)
-      )),
-      replaceIndexes = true
-    )
 
   def pushNew(item: SecureCommsMessageModel, receivedAt: Instant): Future[WorkItem[SecureCommsMessageModel]] =
     super.pushNew(item, receivedAt)

--- a/app/repositories/SecureMessageQueueRepository.scala
+++ b/app/repositories/SecureMessageQueueRepository.scala
@@ -21,7 +21,7 @@ import models.SecureCommsMessageModel
 import org.bson.types.ObjectId
 import org.mongodb.scala.model.Filters.{and, equal}
 import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
-import uk.gov.hmrc.mongo.{MongoComponent, MongoUtils}
+import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.workitem.{WorkItem, WorkItemFields, WorkItemRepository}
 import uk.gov.hmrc.mongo.workitem.ProcessingStatus._
 
@@ -37,22 +37,17 @@ class SecureMessageQueueRepository @Inject()(appConfig: AppConfig, mongoComponen
     "SecureMessageQueue",
     mongoComponent,
     SecureCommsMessageModel.format,
-    WorkItemFields.default
+    WorkItemFields.default,
+    extraIndexes = Seq(IndexModel(
+      Indexes.ascending("receivedAt"),
+      IndexOptions().name("workItemExpiry").expireAfter(appConfig.queueItemExpirySeconds, TimeUnit.SECONDS)
+    )),
+    replaceIndexes = true
   ) {
 
   override lazy val inProgressRetryAfter: Duration = Duration.ofMillis(appConfig.retryIntervalMillis)
 
   override def now(): Instant = Instant.now()
-
-  override def ensureIndexes: Future[Seq[String]] =
-    MongoUtils.ensureIndexes(
-      collection,
-      Seq(IndexModel(
-        Indexes.ascending("receivedAt"),
-        IndexOptions().name("workItemExpiry").expireAfter(appConfig.queueItemExpirySeconds, TimeUnit.SECONDS)
-      )),
-      replaceIndexes = true
-    )
 
   def pushNew(item: SecureCommsMessageModel, receivedAt: Instant): Future[WorkItem[SecureCommsMessageModel]] =
     super.pushNew(item, receivedAt)

--- a/build.sbt
+++ b/build.sbt
@@ -24,13 +24,13 @@ val appName = "mtd-vat-comms"
 lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
 val compile = Seq(
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-work-item-repo-play-28" % "0.74.0",
-  "uk.gov.hmrc"       %% "bootstrap-backend-play-28"         % "7.14.0"
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-work-item-repo-play-28" % "1.1.0",
+  "uk.gov.hmrc"       %% "bootstrap-backend-play-28"         % "7.15.0"
 )
 
 def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc"            %% "bootstrap-test-play-28"       % "7.14.0"            % scope,
-  "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"      % "0.74.0"            % scope,
+  "uk.gov.hmrc"            %% "bootstrap-test-play-28"       % "7.15.0"            % scope,
+  "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"      % "1.1.0"             % scope,
   "org.scalatestplus"      %% "mockito-3-4"                  % "3.2.10.0"          % scope,
   "org.scalamock"          %% "scalamock"                    % "5.2.0"             % scope,
   "org.specs2"             %% "specs2-core"                  % "4.19.1"            % scope

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,12 +19,6 @@ include "backend.conf"
 
 appName = mtd-vat-comms
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
-
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
 play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"

--- a/test/repositories/CommsEventQueueRepositorySpec.scala
+++ b/test/repositories/CommsEventQueueRepositorySpec.scala
@@ -20,6 +20,7 @@ import base.BaseSpec
 import common.ApiConstants.vatChangeEventModel
 import models.VatChangeEvent
 import org.bson.types.ObjectId
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.workitem.WorkItem
@@ -33,6 +34,17 @@ class CommsEventQueueRepositorySpec extends BaseSpec with DefaultPlayMongoReposi
 
     "ensure indexes are created" in {
       await(repository.collection.listIndexes().toFuture()).size shouldBe 5
+    }
+
+    "have a TTL index on the receivedAt field, with an expiry time set by AppConfig" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("workItemExpiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"receivedAt": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(mockAppConfig.queueItemExpirySeconds)
     }
 
     val vatChangeEvent: VatChangeEvent = vatChangeEventModel("PPOB Change")

--- a/test/repositories/EmailMessageQueueRepositorySpec.scala
+++ b/test/repositories/EmailMessageQueueRepositorySpec.scala
@@ -19,6 +19,7 @@ package repositories
 import base.BaseSpec
 import models.SecureCommsMessageModel
 import org.bson.types.ObjectId
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.workitem.WorkItem
@@ -34,6 +35,17 @@ class EmailMessageQueueRepositorySpec extends BaseSpec with
 
     "ensure indexes are created" in {
       await(repository.collection.listIndexes().toFuture()).size shouldBe 5
+    }
+
+    "have a TTL index on the receivedAt field, with an expiry time set by AppConfig" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("workItemExpiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"receivedAt": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(mockAppConfig.queueItemExpirySeconds)
     }
 
     "be able to save and reload an item" in {


### PR DESCRIPTION
We already had TTL indexes set but it looks like hmrc-mongo needs them defined in the repository constructor rather than the ensureIndexes function we were using, or it won't recognise you have them set in the tests and throw failures.

Image showing the TTL index from local mongo:
![image](https://user-images.githubusercontent.com/29063729/227997836-8715e8bf-9507-4ad6-aef8-28f9315a3c11.png)
